### PR TITLE
Finishing constructRoutes, and implementing matchRoute.

### DIFF
--- a/src/matchRoute.js
+++ b/src/matchRoute.js
@@ -1,0 +1,69 @@
+/**
+ *
+ * @param {import('./constructRoutes').ResolvedRoutesConfig} resolvedRoutesConfig
+ * @param {string} path
+ * @returns {import('./constructRoutes').ResolvedRoutesConfig}
+ */
+export function matchRoute(resolvedRoutesConfig, pathMatch) {
+  const result = { ...resolvedRoutesConfig };
+
+  const baseWithoutSlash = resolvedRoutesConfig.base.slice(
+    0,
+    resolvedRoutesConfig.base.length - 1
+  );
+
+  if (pathMatch.startsWith(baseWithoutSlash)) {
+    result.routes = recurseRoutes(
+      pathMatch,
+      resolvedRoutesConfig.base,
+      resolvedRoutesConfig.routes
+    );
+  } else {
+    result.routes = [];
+  }
+
+  return result;
+}
+
+/**
+ *
+ * @param {string} pathMatch
+ * @param {string} startPath
+ * @param {Array<import('./constructRoutes').Route>} routes
+ */
+function recurseRoutes(pathMatch, startPath, routes) {
+  const result = [];
+
+  routes.forEach((route) => {
+    if (route.type === "application") {
+      result.push(route);
+    } else {
+      const resolvedPath = resolvePath(startPath, route.path);
+
+      if (pathMatch.startsWith(resolvedPath)) {
+        result.push({
+          ...route,
+          routes: recurseRoutes(pathMatch, resolvedPath, route.routes),
+        });
+      }
+    }
+  });
+
+  return result;
+}
+
+function resolvePath(prefix, path) {
+  if (prefix.endsWith("/")) {
+    if (path.startsWith("/")) {
+      return prefix + path.slice(1);
+    } else {
+      return prefix + path;
+    }
+  } else {
+    if (path.startsWith("/")) {
+      return prefix + path;
+    } else {
+      return prefix + "/" + path;
+    }
+  }
+}

--- a/src/single-spa-layout.js
+++ b/src/single-spa-layout.js
@@ -1,1 +1,2 @@
 export { constructRoutes } from "./constructRoutes.js";
+export { matchRoute } from "./matchRoute.js";

--- a/src/validation-helpers.js
+++ b/src/validation-helpers.js
@@ -67,7 +67,7 @@ export function validateContainerEl(propertyName, containerEl) {
   if (typeof containerEl === "string") {
     err = containerEl.trim() === "";
   } else if (typeof HTMLElement !== "undefined") {
-    err = containerEl instanceof HTMLElement;
+    err = !(containerEl instanceof HTMLElement);
   } else {
     err = true;
   }

--- a/src/validation-helpers.js
+++ b/src/validation-helpers.js
@@ -61,3 +61,20 @@ export function validateArray(propertyName, arr, cbk) {
     cbk(val, `${propertyName}[${index}]`);
   });
 }
+
+export function validateContainerEl(propertyName, containerEl) {
+  let err;
+  if (typeof containerEl === "string") {
+    err = containerEl.trim() === "";
+  } else if (typeof HTMLElement !== "undefined") {
+    err = containerEl instanceof HTMLElement;
+  } else {
+    err = true;
+  }
+
+  if (err) {
+    throw Error(
+      `Invalid ${propertyName}: received ${containerEl} but expected either non-blank string or HTMLElement`
+    );
+  }
+}

--- a/test/constructRoutes.test.js
+++ b/test/constructRoutes.test.js
@@ -315,6 +315,51 @@ describe("constructRoutes", () => {
         "Invalid routesConfig.routes[1]: received invalid properties 'irrelevantProperty', but valid properties are type, path, routes"
       );
     });
+
+    it(`throws when containerEl is invalid`, () => {
+      expect(() => {
+        constructRoutes({
+          containerEl: null,
+          routes: [],
+        });
+      }).toThrowError(
+        "Invalid routesConfig.containerEl: received null but expected either non-blank string or HTMLElement"
+      );
+
+      expect(() => {
+        constructRoutes({
+          containerEl: [],
+          routes: [],
+        });
+      }).toThrowError(
+        "Invalid routesConfig.containerEl: received  but expected either non-blank string or HTMLElement"
+      );
+
+      expect(() => {
+        constructRoutes({
+          containerEl: 2342,
+          routes: [],
+        });
+      }).toThrowError(
+        "Invalid routesConfig.containerEl: received 2342 but expected either non-blank string or HTMLElement"
+      );
+    });
+
+    it(`allows a string containerEl`, () => {
+      constructRoutes({
+        containerEl: "asdf",
+        routes: [],
+      });
+    });
+
+    if (typeof HTMLElement !== "undefined") {
+      it("allows an HTMLElement containerEl", () => {
+        constructRoutes({
+          containerEl: document.createElement("div"),
+          routes: [],
+        });
+      });
+    }
   });
 
   describe(`return value`, () => {

--- a/test/constructRoutes.test.js
+++ b/test/constructRoutes.test.js
@@ -10,7 +10,7 @@ describe("constructRoutes", () => {
     console.warn.mockReset();
   });
 
-  describe(`input validation`, () => {
+  describe(`validates top level properties`, () => {
     it("accepts a valid routesConfig", () => {
       constructRoutes({
         mode: "history",
@@ -43,90 +43,90 @@ describe("constructRoutes", () => {
         ],
       });
     });
-  });
 
-  it(`throws an error if the first argument is not an object`, () => {
-    expect(() => {
-      constructRoutes();
-    }).toThrowError(/expected a plain object/);
+    it(`throws an error if the first argument is not an object`, () => {
+      expect(() => {
+        constructRoutes();
+      }).toThrowError(/expected a plain object/);
 
-    expect(() => {
-      constructRoutes(null);
-    }).toThrowError(/expected a plain object/);
+      expect(() => {
+        constructRoutes(null);
+      }).toThrowError(/expected a plain object/);
 
-    expect(() => {
-      constructRoutes("");
-    }).toThrowError(/expected a plain object/);
+      expect(() => {
+        constructRoutes("");
+      }).toThrowError(/expected a plain object/);
 
-    expect(() => {
-      constructRoutes(undefined);
-    }).toThrowError(/expected a plain object/);
+      expect(() => {
+        constructRoutes(undefined);
+      }).toThrowError(/expected a plain object/);
 
-    expect(() => {
-      constructRoutes([]);
-    }).toThrowError(/expected a plain object/);
-  });
-
-  it(`console.warns if extra properties are provided`, () => {
-    constructRoutes({
-      routes: [],
-      irrelevantProperty: "thing",
+      expect(() => {
+        constructRoutes([]);
+      }).toThrowError(/expected a plain object/);
     });
-    expect(console.warn).toHaveBeenCalled();
-    expect(console.warn.mock.calls[0][0].message).toEqual(
-      `Invalid routesConfig: received invalid properties 'irrelevantProperty', but valid properties are mode, base, containerEl, routes, disableWarnings`
-    );
-  });
 
-  it(`validates the mode correctly`, () => {
-    expect(() => {
+    it(`console.warns if extra properties are provided`, () => {
       constructRoutes({
-        mode: "wrong",
+        routes: [],
+        irrelevantProperty: "thing",
+      });
+      expect(console.warn).toHaveBeenCalled();
+      expect(console.warn.mock.calls[0][0].message).toEqual(
+        `Invalid routesConfig: received invalid properties 'irrelevantProperty', but valid properties are mode, base, containerEl, routes, disableWarnings`
+      );
+    });
+
+    it(`validates the mode correctly`, () => {
+      expect(() => {
+        constructRoutes({
+          mode: "wrong",
+          routes: [],
+        });
+      }).toThrowError("mode");
+
+      constructRoutes({
+        mode: "hash",
         routes: [],
       });
-    }).toThrowError("mode");
 
-    constructRoutes({
-      mode: "hash",
-      routes: [],
-    });
-
-    constructRoutes({
-      mode: "history",
-      routes: [],
-    });
-  });
-
-  it(`validates the base correctly`, () => {
-    constructRoutes({
-      base: "/",
-      mode: "history",
-      routes: [],
-    });
-
-    expect(() => {
       constructRoutes({
-        base: "",
         mode: "history",
         routes: [],
       });
-    }).toThrowError("non-blank string");
+    });
 
-    expect(() => {
+    it(`validates the base correctly`, () => {
       constructRoutes({
-        base: "  ",
+        base: "/",
         mode: "history",
         routes: [],
       });
-    }).toThrowError("non-blank string");
 
-    expect(() => {
-      constructRoutes({
-        base: null,
-        mode: "history",
-        routes: [],
-      });
-    }).toThrowError("non-blank string");
+      expect(() => {
+        constructRoutes({
+          base: "",
+          mode: "history",
+          routes: [],
+        });
+      }).toThrowError("non-blank string");
+
+      expect(() => {
+        constructRoutes({
+          base: "  ",
+          mode: "history",
+          routes: [],
+        });
+      }).toThrowError("non-blank string");
+
+      expect(() => {
+        constructRoutes({
+          base: null,
+          mode: "history",
+          routes: [],
+        });
+      }).toThrowError("non-blank string");
+    });
   });
 
   describe("validates routes", () => {
@@ -146,6 +146,22 @@ describe("constructRoutes", () => {
       }).toThrowError("array");
     });
 
+    it(`checks for presence of route array`, () => {
+      expect(() => {
+        constructRoutes({
+          mode: "history",
+          routes: [
+            {
+              type: "route",
+              path: "/",
+            },
+          ],
+        });
+      }).toThrowError(
+        `Invalid routesConfig.routes[0].routes: received 'undefined', but expected an array`
+      );
+    });
+
     it(`checks for valid route objects`, () => {
       constructRoutes({
         mode: "history",
@@ -153,6 +169,7 @@ describe("constructRoutes", () => {
           {
             type: "route",
             path: "/",
+            routes: [],
           },
         ],
       });
@@ -164,6 +181,7 @@ describe("constructRoutes", () => {
           {
             type: "route",
             path: "/",
+            routes: [],
             somethingElse: "value",
           },
         ],
@@ -265,10 +283,12 @@ describe("constructRoutes", () => {
           {
             type: "route",
             path: "/",
+            routes: [],
           },
           {
             type: "route",
             path: "/app1",
+            routes: [],
           },
         ],
       });
@@ -280,10 +300,12 @@ describe("constructRoutes", () => {
           {
             type: "route",
             path: "/",
+            routes: [],
           },
           {
             type: "route",
             path: "/app1",
+            routes: [],
             irrelevantProperty: "thing",
           },
         ],
@@ -292,6 +314,53 @@ describe("constructRoutes", () => {
       expect(console.warn.mock.calls[0][0].message).toEqual(
         "Invalid routesConfig.routes[1]: received invalid properties 'irrelevantProperty', but valid properties are type, path, routes"
       );
+    });
+  });
+
+  describe(`return value`, () => {
+    it(`adds a default base if one is not provided`, () => {
+      expect(
+        constructRoutes({
+          containerEl: "body",
+          mode: "history",
+          routes: [{ type: "application", name: "nav" }],
+        })
+      ).toEqual({
+        base: "/",
+        containerEl: "body",
+        mode: "history",
+        routes: [{ type: "application", name: "nav" }],
+      });
+    });
+
+    it(`adds a default mode if one is not provided`, () => {
+      expect(
+        constructRoutes({
+          containerEl: "body",
+          base: "/",
+          routes: [{ type: "application", name: "nav" }],
+        })
+      ).toEqual({
+        base: "/",
+        containerEl: "body",
+        mode: "history",
+        routes: [{ type: "application", name: "nav" }],
+      });
+    });
+
+    it(`adds a default containerEl if one is not provided`, () => {
+      expect(
+        constructRoutes({
+          base: "/",
+          mode: "history",
+          routes: [{ type: "application", name: "nav" }],
+        })
+      ).toEqual({
+        base: "/",
+        containerEl: "body",
+        mode: "history",
+        routes: [{ type: "application", name: "nav" }],
+      });
     });
   });
 });

--- a/test/matchRoute.test.js
+++ b/test/matchRoute.test.js
@@ -1,0 +1,126 @@
+import { matchRoute } from "../src/single-spa-layout.js";
+
+describe(`matchRoute`, () => {
+  let routesConfig;
+
+  beforeEach(() => {
+    routesConfig = {
+      mode: "history",
+      base: "/",
+      containerEl: "body",
+      routes: [
+        { type: "application", name: "nav" },
+        {
+          type: "route",
+          path: "app1",
+          routes: [
+            { type: "application", name: "app1" },
+            {
+              type: "route",
+              path: "subroute",
+              routes: [{ type: "application", name: "subroute" }],
+            },
+          ],
+        },
+        {
+          type: "route",
+          path: "app2",
+          routes: [
+            { type: "application", name: "app2" },
+            {
+              type: "route",
+              path: "subroute",
+              routes: [{ type: "application", name: "subroute" }],
+            },
+          ],
+        },
+        { type: "application", name: "footer" },
+      ],
+    };
+  });
+
+  it(`returns a filtered routes array`, () => {
+    expect(matchRoute(routesConfig, "/")).toEqual({
+      ...routesConfig,
+      routes: [
+        { type: "application", name: "nav" },
+        { type: "application", name: "footer" },
+      ],
+    });
+  });
+
+  it(`matches nested routes`, () => {
+    expect(matchRoute(routesConfig, "/app1")).toEqual({
+      ...routesConfig,
+      routes: [
+        { type: "application", name: "nav" },
+        {
+          type: "route",
+          path: "app1",
+          routes: [{ type: "application", name: "app1" }],
+        },
+        { type: "application", name: "footer" },
+      ],
+    });
+
+    expect(matchRoute(routesConfig, "/app2")).toEqual({
+      ...routesConfig,
+      routes: [
+        { type: "application", name: "nav" },
+        {
+          type: "route",
+          path: "app2",
+          routes: [{ type: "application", name: "app2" }],
+        },
+        { type: "application", name: "footer" },
+      ],
+    });
+  });
+
+  it(`matches deeply nested routes`, () => {
+    expect(matchRoute(routesConfig, "/app1/subroute")).toEqual({
+      ...routesConfig,
+      routes: [
+        { type: "application", name: "nav" },
+        {
+          type: "route",
+          path: "app1",
+          routes: [
+            { type: "application", name: "app1" },
+            {
+              type: "route",
+              path: "subroute",
+              routes: [{ type: "application", name: "subroute" }],
+            },
+          ],
+        },
+        { type: "application", name: "footer" },
+      ],
+    });
+  });
+
+  it(`matches using base name`, () => {
+    routesConfig.base = "/base/";
+
+    expect(matchRoute(routesConfig, "/")).toEqual({
+      ...routesConfig,
+      routes: [],
+    });
+
+    expect(matchRoute(routesConfig, "/base/")).toEqual({
+      ...routesConfig,
+      routes: [
+        { type: "application", name: "nav" },
+        { type: "application", name: "footer" },
+      ],
+    });
+
+    expect(matchRoute(routesConfig, "/base")).toEqual({
+      ...routesConfig,
+      routes: [
+        { type: "application", name: "nav" },
+        { type: "application", name: "footer" },
+      ],
+    });
+  });
+});

--- a/test/single-spa-layout.test-d.ts
+++ b/test/single-spa-layout.test-d.ts
@@ -1,12 +1,26 @@
 import { expectError, expectType } from "tsd";
-import { constructRoutes } from "../src/single-spa-layout";
+import { constructRoutes, matchRoute } from "../src/single-spa-layout";
 
-expectType<any>(
-  constructRoutes({
-    routes: [],
-  })
-);
-
+// test constructRoutes
 expectError(constructRoutes());
 
 expectError(constructRoutes({}));
+
+const routes = constructRoutes({
+  routes: [
+    {
+      type: "route",
+      path: "/app1",
+      routes: [{ type: "application", name: "app1" }],
+    },
+  ],
+});
+
+// test matchRoute
+const matchedRoutes = matchRoute(routes, "/");
+expectType<string>(matchedRoutes.base);
+expectType<import("../src/constructRoutes").ContainerEl>(
+  matchedRoutes.containerEl
+);
+expectType<string>(matchedRoutes.mode);
+expectType<Array<import("../src/constructRoutes").Route>>(matchedRoutes.routes);


### PR DESCRIPTION
`matchRoute` will be used internally by single-spa-layout, but I'm exposing it because I think it'll be useful for server rendering code to call it directly