### PR TITLE
Support for dynamic route parameters. Resolves #9.

### DIFF
--- a/src/constructApplications.js
+++ b/src/constructApplications.js
@@ -26,7 +26,6 @@ export function constructApplications({ routes, loadApp }) {
   /** @type {ApplicationMap} */
   const applicationMap = {};
 
-  const topLevelActiveWhen = () => true;
   recurseRoutes(applicationMap, topLevelActiveWhen, {}, routes.routes);
 
   /**
@@ -91,4 +90,9 @@ function recurseRoutes(applicationMap, activeWhen, props, routes) {
 
 function mergeProps(originalProps, newProps = {}) {
   return { ...originalProps, ...newProps };
+}
+
+function topLevelActiveWhen() {
+  // All applications not under routes are active
+  return true;
 }

--- a/src/constructLayoutEngine.js
+++ b/src/constructLayoutEngine.js
@@ -73,7 +73,7 @@ export function constructLayoutEngine({
   function arrangeDomElements() {
     const path = location[resolvedRoutes.mode === "hash" ? "hash" : "pathname"];
 
-    if (!path.startsWith(baseWithoutSlash)) {
+    if (path.indexOf(baseWithoutSlash) !== 0) {
       // Base URL doesn't match, no need to recurse routes
       return;
     }
@@ -84,8 +84,7 @@ export function constructLayoutEngine({
         : resolvedRoutes.containerEl;
 
     recurseRoutes({
-      path,
-      pathMatch: baseWithoutSlash,
+      location: window.location,
       routes: resolvedRoutes.routes,
       parentContainer,
       shouldMount: true,
@@ -112,8 +111,7 @@ export function constructLayoutEngine({
 
 /**
  * @typedef {{
- * path: string,
- * pathMatch: string,
+ * location: URL,
  * routes: Array<import('./constructRoutes').Route>,
  * parentContainer: HTMLElement,
  * previousSibling?: HTMLElement,
@@ -128,8 +126,7 @@ export function constructLayoutEngine({
  * @returns {HTMLElement}
  */
 function recurseRoutes({
-  path,
-  pathMatch,
+  location,
   routes,
   parentContainer,
   previousSibling,
@@ -150,14 +147,12 @@ function recurseRoutes({
         previousSibling = applicationElement;
       }
     } else if (route.type === "route") {
-      const childPathMatch = resolvePath(pathMatch, route.path);
       previousSibling = recurseRoutes({
-        path,
-        pathMatch: childPathMatch,
+        location,
         routes: route.routes,
         parentContainer,
         previousSibling,
-        shouldMount: shouldMount && path.startsWith(childPathMatch),
+        shouldMount: shouldMount && route.activeWhen(location),
         pendingRemovals,
       });
     } else if (route instanceof Node) {
@@ -169,8 +164,7 @@ function recurseRoutes({
         }
 
         recurseRoutes({
-          path,
-          pathMatch,
+          location,
           routes: route.routes,
           parentContainer: route.connectedNode,
           previousSibling: null,

--- a/src/validation-helpers.js
+++ b/src/validation-helpers.js
@@ -52,7 +52,7 @@ export function validateString(propertyName, val) {
   }
 }
 
-export function validateArray(propertyName, arr, cbk) {
+export function validateArray(propertyName, arr, cbk, ...extraArgs) {
   if (
     !Array.isArray(arr) &&
     (typeof typeof arr !== "object" || arr.length !== "number")
@@ -63,7 +63,7 @@ export function validateArray(propertyName, arr, cbk) {
   }
 
   for (let i = 0; i < arr.length; i++) {
-    cbk(arr[i], `${propertyName}[${i}]`);
+    cbk(arr[i], `${propertyName}[${i}]`, ...extraArgs);
   }
 }
 

--- a/test/browser-only/constructLayoutEngine-browser.test.js
+++ b/test/browser-only/constructLayoutEngine-browser.test.js
@@ -19,12 +19,12 @@ describe(`constructLayoutEngine browser`, () => {
 
   it(`starts out activated`, () => {
     /** @type {import('../../src/constructRoutes').ResolvedRoutesConfig} */
-    const routes = {
+    const routes = constructRoutes({
       containerEl: "body",
       base: "/",
       mode: "history",
       routes: [{ type: "application", name: "@org-name/header" }],
-    };
+    });
 
     layoutEngine = constructLayoutEngine({
       routes,
@@ -35,12 +35,12 @@ describe(`constructLayoutEngine browser`, () => {
 
   it(`can handle any calls to activate() / deactivate()`, () => {
     /** @type {import('../../src/constructRoutes').ResolvedRoutesConfig} */
-    const routes = {
+    const routes = constructRoutes({
       containerEl: "body",
       base: "/",
       mode: "history",
       routes: [{ type: "application", name: "@org-name/header" }],
-    };
+    });
 
     layoutEngine = constructLayoutEngine({
       routes,
@@ -62,7 +62,7 @@ describe(`constructLayoutEngine browser`, () => {
 
   it(`can successfully construct a layout engine and respond to routing events`, () => {
     /** @type {import('../../src/constructRoutes').ResolvedRoutesConfig} */
-    const routes = {
+    const routes = constructRoutes({
       containerEl: "body",
       base: "/",
       mode: "history",
@@ -75,7 +75,7 @@ describe(`constructLayoutEngine browser`, () => {
         },
         { type: "application", name: "@org-name/footer" },
       ],
-    };
+    });
 
     layoutEngine = constructLayoutEngine({
       routes,
@@ -180,7 +180,7 @@ describe(`constructLayoutEngine browser`, () => {
     let headerEl, footerEl, app1El, app2El;
 
     /** @type {import('../../src/constructRoutes').ResolvedRoutesConfig} */
-    const routes = {
+    const routes = constructRoutes({
       containerEl: "body",
       base: "/",
       mode: "history",
@@ -204,7 +204,7 @@ describe(`constructLayoutEngine browser`, () => {
         },
         { type: "application", name: "@org-name/footer" },
       ],
-    };
+    });
 
     layoutEngine = constructLayoutEngine({
       routes,

--- a/test/constructApplications.test.js
+++ b/test/constructApplications.test.js
@@ -6,7 +6,7 @@ import { parseFixture } from "./html-utils.js";
 
 describe(`constructApplications`, () => {
   it(`can handle a medium complexity case`, () => {
-    const routes = {
+    const routes = constructRoutes({
       mode: "history",
       base: "/",
       containerEl: "body",
@@ -42,39 +42,72 @@ describe(`constructApplications`, () => {
         },
         { type: "application", name: "footer" },
       ],
-    };
+    });
 
     const loadApp = jest.fn();
 
     const applications = constructApplications({ routes, loadApp });
 
-    const activeWhens = applications.map((app) => ({
-      name: app.name,
-      activeWhen: app.activeWhen,
-    }));
+    expect(applications.length).toBe(5);
+    expect(applications[0].name).toBe("nav");
+    expect(
+      applications[0].activeWhen.some((fn) => fn(new URL("http://localhost")))
+    ).toBe(true);
+    expect(
+      applications[0].activeWhen.some((fn) =>
+        fn(new URL("http://localhost/app1"))
+      )
+    ).toBe(true);
 
-    expect(activeWhens).toEqual([
-      {
-        name: "nav",
-        activeWhen: ["/"],
-      },
-      {
-        name: "app1",
-        activeWhen: ["/app1"],
-      },
-      {
-        name: "subroute",
-        activeWhen: ["/app1/subroute", "/app2/subroute"],
-      },
-      {
-        name: "app2",
-        activeWhen: ["/app2"],
-      },
-      {
-        name: "footer",
-        activeWhen: ["/"],
-      },
-    ]);
+    expect(applications[1].name).toBe("app1");
+    expect(
+      applications[1].activeWhen.some((fn) => fn(new URL("http://localhost")))
+    ).toBe(false);
+    expect(
+      applications[1].activeWhen.some((fn) =>
+        fn(new URL("http://localhost/app1"))
+      )
+    ).toBe(true);
+
+    expect(applications[2].name).toBe("subroute");
+    expect(
+      applications[2].activeWhen.some((fn) => fn(new URL("http://localhost")))
+    ).toBe(false);
+    expect(
+      applications[2].activeWhen.some((fn) =>
+        fn(new URL("http://localhost/app1"))
+      )
+    ).toBe(false);
+    expect(
+      applications[2].activeWhen.some((fn) =>
+        fn(new URL("http://localhost/app1/subroute"))
+      )
+    ).toBe(true);
+    expect(
+      applications[2].activeWhen.some((fn) =>
+        fn(new URL("http://localhost/app2/subroute"))
+      )
+    ).toBe(true);
+
+    expect(applications[3].name).toBe("app2");
+    expect(
+      applications[3].activeWhen.some((fn) => fn(new URL("http://localhost")))
+    ).toBe(false);
+    expect(
+      applications[3].activeWhen.some((fn) =>
+        fn(new URL("http://localhost/app2"))
+      )
+    ).toBe(true);
+
+    expect(applications[4].name).toBe("footer");
+    expect(
+      applications[4].activeWhen.some((fn) => fn(new URL("http://localhost")))
+    ).toBe(true);
+    expect(
+      applications[4].activeWhen.some((fn) =>
+        fn(new URL("http://localhost/app2"))
+      )
+    ).toBe(true);
 
     expect(
       applications
@@ -147,8 +180,23 @@ describe(`constructApplications`, () => {
     const applications = constructApplications({ routes, loadApp });
     expect(applications.length).toBe(2);
     expect(applications[0].name).toBe("header");
-    expect(applications[0].activeWhen).toEqual(["/"]);
+    expect(
+      applications[0].activeWhen.some((fn) => fn(new URL("http://localhost/")))
+    ).toBe(true);
+    expect(
+      applications[0].activeWhen.some((fn) =>
+        fn(new URL("http://localhost/app1"))
+      )
+    ).toBe(true);
+
     expect(applications[1].name).toBe("app1");
-    expect(applications[1].activeWhen).toEqual(["/app1"]);
+    expect(
+      applications[1].activeWhen.some((fn) => fn(new URL("http://localhost/")))
+    ).toBe(false);
+    expect(
+      applications[1].activeWhen.some((fn) =>
+        fn(new URL("http://localhost/app1"))
+      )
+    ).toBe(true);
   });
 });

--- a/test/matchRoute.test.js
+++ b/test/matchRoute.test.js
@@ -1,10 +1,10 @@
-import { matchRoute } from "../src/single-spa-layout.js";
+import { matchRoute, constructRoutes } from "../src/single-spa-layout.js";
 
 describe(`matchRoute`, () => {
   let routesConfig;
 
   beforeEach(() => {
-    routesConfig = {
+    routesConfig = constructRoutes({
       mode: "history",
       base: "/",
       containerEl: "body",
@@ -34,9 +34,21 @@ describe(`matchRoute`, () => {
             },
           ],
         },
+        {
+          type: "route",
+          path: "users/:id",
+          routes: [
+            { type: "application", name: "user-home" },
+            {
+              type: "route",
+              path: "settings",
+              routes: [{ type: "application", name: "user-settings" }],
+            },
+          ],
+        },
         { type: "application", name: "footer" },
       ],
-    };
+    });
   });
 
   it(`returns a filtered routes array`, () => {
@@ -50,7 +62,7 @@ describe(`matchRoute`, () => {
   });
 
   it(`matches nested routes`, () => {
-    expect(matchRoute(routesConfig, "/app1")).toEqual({
+    expect(matchRoute(routesConfig, "/app1")).toMatchObject({
       ...routesConfig,
       routes: [
         { type: "application", name: "nav" },
@@ -63,7 +75,7 @@ describe(`matchRoute`, () => {
       ],
     });
 
-    expect(matchRoute(routesConfig, "/app2")).toEqual({
+    expect(matchRoute(routesConfig, "/app2")).toMatchObject({
       ...routesConfig,
       routes: [
         { type: "application", name: "nav" },
@@ -78,7 +90,7 @@ describe(`matchRoute`, () => {
   });
 
   it(`matches deeply nested routes`, () => {
-    expect(matchRoute(routesConfig, "/app1/subroute")).toEqual({
+    expect(matchRoute(routesConfig, "/app1/subroute")).toMatchObject({
       ...routesConfig,
       routes: [
         { type: "application", name: "nav" },
@@ -119,6 +131,41 @@ describe(`matchRoute`, () => {
       ...routesConfig,
       routes: [
         { type: "application", name: "nav" },
+        { type: "application", name: "footer" },
+      ],
+    });
+  });
+
+  it(`matches dynamic paths`, () => {
+    expect(matchRoute(routesConfig, "users/123")).toMatchObject({
+      ...routesConfig,
+      routes: [
+        { type: "application", name: "nav" },
+        {
+          type: "route",
+          path: "users/:id",
+          routes: [{ type: "application", name: "user-home" }],
+        },
+        { type: "application", name: "footer" },
+      ],
+    });
+
+    expect(matchRoute(routesConfig, "users/123/settings")).toMatchObject({
+      ...routesConfig,
+      routes: [
+        { type: "application", name: "nav" },
+        {
+          type: "route",
+          path: "users/:id",
+          routes: [
+            { type: "application", name: "user-home" },
+            {
+              type: "route",
+              path: "settings",
+              routes: [{ type: "application", name: "user-settings" }],
+            },
+          ],
+        },
         { type: "application", name: "footer" },
       ],
     });

--- a/test/single-spa-layout.test-d.ts
+++ b/test/single-spa-layout.test-d.ts
@@ -14,6 +14,7 @@ import {
   constructLayoutEngine,
 } from "../src/single-spa-layout";
 import { parse, Element, DefaultTreeDocument } from "parse5";
+import { ResolvedUrlRoute } from "../src/constructRoutes";
 
 // test constructRoutes
 expectError(constructRoutes());
@@ -32,6 +33,8 @@ const routes = constructRoutes({
   ],
 });
 
+(routes.routes[0] as ResolvedUrlRoute).activeWhen(window.location);
+
 const parse5Doc = parse(
   `<single-spa-router></single-spa-router>`
 ) as DefaultTreeDocument;
@@ -45,7 +48,7 @@ expectType<import("../src/constructRoutes").ContainerEl>(
   matchedRoutes.containerEl
 );
 expectType<string>(matchedRoutes.mode);
-expectType<Array<import("../src/constructRoutes").RouteChild>>(
+expectType<Array<import("../src/constructRoutes").ResolvedRouteChild>>(
   matchedRoutes.routes
 );
 


### PR DESCRIPTION
See #9. This PR is sorta big and complicated - the main change is that we're no longer doing `path.startsWith` and are instead doing `activeWhen(window.location)`

Note that this does not fully support the following scenario:

```js
const routes = constructRoutes({
  routes: [
    { type: 'route', path: "/user/new", routes: [] },
    { type: 'route', path: "/user/:id", routes: [] },
  ]
})
```

In this case, the desired behavior is likely that for route `/user/new` that only the first route would match instead of both. However, the behavior in this PR is that both routes would match.