### PR TITLE
Removing router template from dom. Resolves #32.

### DIFF
--- a/cypress/integration/basic-html-file.spec.js
+++ b/cypress/integration/basic-html-file.spec.js
@@ -30,6 +30,9 @@ describe("basic html example", () => {
     applications.forEach(singleSpa.registerApplication);
     singleSpa.start();
 
+    expect(contentWindow.document.querySelector("single-spa-router")).to.be
+      .null;
+
     await singleSpa.triggerAppChange();
     expect(
       contentWindow.document.getElementById(applicationElementId("header"))

--- a/src/constructRoutes.js
+++ b/src/constructRoutes.js
@@ -96,6 +96,10 @@ function domToRoutesConfig(domElement, htmlLayoutData = {}) {
     );
   }
 
+  if (inBrowser && domElement.isConnected) {
+    domElement.parentNode.removeChild(domElement);
+  }
+
   const result = {
     routes: [],
   };


### PR DESCRIPTION
See #32. If the `<single-spa-router>` element is in the DOM, we should remove it. That dom element is used to constructRoutes, but is not used to render UI.