### PR TITLE
Fixing rollupjs warnings

### DIFF
--- a/rollup.config.js
+++ b/rollup.config.js
@@ -17,7 +17,11 @@ function createConfig(format) {
       file: `dist/${format}/single-spa-layout.min.js`,
       name: format === "umd" ? "singleSpaLayout" : null,
       banner: `/* single-spa-layout@${packageJson.version} - ${format} */`,
+      globals: {
+        "single-spa": "singleSpa",
+      },
     },
+    external: ["single-spa"],
     plugins: [
       terser({
         compress: {


### PR DESCRIPTION
Before:

```
yarn build
yarn run v1.22.4
$ rimraf dist && concurrently -n w: 'yarn:build:*'
$ rollup -c
$ tsc
[build:lib] 
[build:lib] ./src/single-spa-layout.js → dist/esm/single-spa-layout.min.js...
[build:lib] (!) Unresolved dependencies
[build:lib] https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
[build:lib] single-spa (imported by src/constructRoutes.js, src/constructApplications.js)
[build:lib] created dist/esm/single-spa-layout.min.js in 476ms
[build:lib] 
[build:lib] ./src/single-spa-layout.js → dist/system/single-spa-layout.min.js...
[build:lib] (!) Unresolved dependencies
[build:lib] https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
[build:lib] single-spa (imported by src/constructApplications.js, src/constructRoutes.js)
[build:lib] created dist/system/single-spa-layout.min.js in 470ms
[build:lib] 
[build:lib] ./src/single-spa-layout.js → dist/umd/single-spa-layout.min.js...
[build:lib] (!) Unresolved dependencies
[build:lib] https://rollupjs.org/guide/en/#warning-treating-module-as-external-dependency
[build:lib] single-spa (imported by src/constructRoutes.js, src/constructApplications.js)
[build:lib] created dist/umd/single-spa-layout.min.js in 510ms
[build:lib] yarn run build:lib exited with code 0
[build:types] yarn run build:types exited with code 0
```

After:

```
yarn build
yarn run v1.22.4
$ rimraf dist && concurrently -n w: 'yarn:build:*'
$ tsc
$ rollup -c 
[build:lib] 
[build:lib] ./src/single-spa-layout.js → dist/esm/single-spa-layout.min.js...
[build:lib] created dist/esm/single-spa-layout.min.js in 526ms
[build:lib] 
[build:lib] ./src/single-spa-layout.js → dist/system/single-spa-layout.min.js...
[build:lib] created dist/system/single-spa-layout.min.js in 560ms
[build:lib] 
[build:lib] ./src/single-spa-layout.js → dist/umd/single-spa-layout.min.js...
[build:lib] created dist/umd/single-spa-layout.min.js in 552ms
[build:lib] yarn run build:lib exited with code 0
[build:types] yarn run build:types exited with code 0
```