### PR TITLE
Fix bug with application-less route changes

### DIFF
--- a/src/constructLayoutEngine.js
+++ b/src/constructLayoutEngine.js
@@ -43,7 +43,7 @@ export function constructLayoutEngine({
           arrangeDomElements
         );
 
-        window.addEventListener("single-spa:app-change", handleAppChange);
+        window.addEventListener("single-spa:routing-event", handleRoutingEvent);
 
         arrangeDomElements();
       }
@@ -61,7 +61,10 @@ export function constructLayoutEngine({
           arrangeDomElements
         );
 
-        window.removeEventListener("single-spa:app-change", handleAppChange);
+        window.removeEventListener(
+          "single-spa:routing-event",
+          handleRoutingEvent
+        );
       }
     },
   };
@@ -92,7 +95,7 @@ export function constructLayoutEngine({
     });
   }
 
-  function handleAppChange({ detail: { appsByNewStatus } }) {
+  function handleRoutingEvent({ detail: { appsByNewStatus } }) {
     pendingRemovals.forEach((remove) => remove());
     pendingRemovals = [];
 

--- a/test/browser-only/constructLayoutEngine-browser.test.js
+++ b/test/browser-only/constructLayoutEngine-browser.test.js
@@ -108,7 +108,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: ["@org-name/app1"],
@@ -148,7 +148,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: [],
@@ -217,7 +217,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: [],
@@ -260,7 +260,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: [],
@@ -345,7 +345,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: ["@org/settings"],
@@ -364,7 +364,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: [],
@@ -382,7 +382,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: ["@org/main-sidenav", "@org/app1"],
@@ -400,7 +400,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: [],
@@ -418,7 +418,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: ["@org/main-sidenav", "@org/app2"],
@@ -436,7 +436,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: ["@org/app1"],
@@ -460,7 +460,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: ["header"],
@@ -479,7 +479,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: ["app1"],
@@ -497,7 +497,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: [],
@@ -527,7 +527,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: ["settings-not-found"],
@@ -545,7 +545,7 @@ describe(`constructLayoutEngine browser`, () => {
       new CustomEvent("single-spa:before-mount-routing-event")
     );
     window.dispatchEvent(
-      new CustomEvent("single-spa:app-change", {
+      new CustomEvent("single-spa:routing-event", {
         detail: {
           appsByNewStatus: {
             MOUNTED: ["app1"],


### PR DESCRIPTION
It is possible in single-spa-layout to define routes that only contain dom elements, not applications. In those cases, listening to single-spa's `app-change` event is not sufficient, as that event only fires when an application's status has changed. The effect was that stale dom elements stuck around and were never removed.

By switching to the `routing-event`, we'll catch these situations now. Doing so means that single-spa-layout runs more frequently, but that is necessary.

More info at https://single-spa.js.org/docs/api#custom-events