### PR TITLE
Allow for inactive initialization of layoutEngine.

### DIFF
--- a/src/constructLayoutEngine.js
+++ b/src/constructLayoutEngine.js
@@ -19,8 +19,9 @@ import { inBrowser } from "./environment-helpers";
 export function constructLayoutEngine({
   routes: resolvedRoutes,
   applications,
+  active = true,
 }) {
-  let active = false;
+  let isActive = false;
   let pendingRemovals = [];
 
   const baseWithoutSlash = resolvedRoutes.base.slice(
@@ -29,12 +30,12 @@ export function constructLayoutEngine({
   );
 
   const layoutEngine = {
-    isActive: () => active,
+    isActive: () => isActive,
     activate() {
-      if (active) {
+      if (isActive) {
         return;
       } else {
-        active = true;
+        isActive = true;
       }
 
       if (inBrowser) {
@@ -49,10 +50,10 @@ export function constructLayoutEngine({
       }
     },
     deactivate() {
-      if (!active) {
+      if (!isActive) {
         return;
       } else {
-        active = false;
+        isActive = false;
       }
 
       if (inBrowser) {
@@ -66,7 +67,9 @@ export function constructLayoutEngine({
     },
   };
 
-  layoutEngine.activate();
+  if (active) {
+    layoutEngine.activate();
+  }
 
   return layoutEngine;
 

--- a/test/browser-only/constructLayoutEngine-browser.test.js
+++ b/test/browser-only/constructLayoutEngine-browser.test.js
@@ -18,7 +18,7 @@ describe(`constructLayoutEngine browser`, () => {
     }
   });
 
-  it(`starts out activated`, () => {
+  it(`starts out activated by default`, () => {
     /** @type {import('../../src/constructRoutes').ResolvedRoutesConfig} */
     const routes = constructRoutes({
       containerEl: "body",
@@ -32,6 +32,40 @@ describe(`constructLayoutEngine browser`, () => {
     });
 
     expect(layoutEngine.isActive()).toBe(true);
+  });
+
+  it(`starts out activated if forced active`, () => {
+    /** @type {import('../../src/constructRoutes').ResolvedRoutesConfig} */
+    const routes = constructRoutes({
+      containerEl: "body",
+      base: "/",
+      mode: "history",
+      routes: [{ type: "application", name: "@org-name/header" }],
+    });
+
+    layoutEngine = constructLayoutEngine({
+      routes,
+      active: true,
+    });
+
+    expect(layoutEngine.isActive()).toBe(true);
+  });
+
+  it(`can start off deactivated if specified in options object`, () => {
+    /** @type {import('../../src/constructRoutes').ResolvedRoutesConfig} */
+    const routes = constructRoutes({
+      containerEl: "body",
+      base: "/",
+      mode: "history",
+      routes: [{ type: "application", name: "@org-name/header" }],
+    });
+
+    layoutEngine = constructLayoutEngine({
+      routes,
+      active: false,
+    });
+
+    expect(layoutEngine.isActive()).toBe(false);
   });
 
   it(`can handle any calls to activate() / deactivate()`, () => {


### PR DESCRIPTION
This might be desireable when you need to wait to load some CSS before letting the layout engine do its first pass of inserting dom elements.