### PR TITLE
Fixing tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
     "test-e2e:chrome": "cypress run --browser chrome"
   },
   "files": [
-    "dist"
+    "dist",
+    "dist/types/single-spa-layout.d.ts"
   ],
   "tsd": {
     "directory": "test"


### PR DESCRIPTION
I broke the tests in https://github.com/single-spa/single-spa-layout/commit/75f5044e3754f635dc3d47bd68dc5c64d6c3f2d5. `tsd` (typescript tests) don't understand the package.json `files` property very well and require you to put the full path for the types file (not just the directory containing it) into your package.json files.