### PR TITLE
Add support for using <template> element to hide content.

### DIFF
--- a/src/constructRoutes.js
+++ b/src/constructRoutes.js
@@ -102,7 +102,7 @@ function domToRoutesConfig(domElement, htmlLayoutData = {}) {
 
   if (domElement.nodeName.toLowerCase() !== "single-spa-router") {
     throw Error(
-      `single-spa-layout: The HTMLElement passed to constructRoutes must be <single-spa-router>. Received ${domElement.nodeName}`
+      `single-spa-layout: The HTMLElement passed to constructRoutes must be <single-spa-router> or a <template> containing the router. Received ${domElement.nodeName}`
     );
   }
 

--- a/src/constructRoutes.js
+++ b/src/constructRoutes.js
@@ -91,6 +91,15 @@ export function constructRoutes(routesConfig, htmlLayoutData) {
  * @returns {InputRoutesConfigObject}
  */
 function domToRoutesConfig(domElement, htmlLayoutData = {}) {
+  // Support passing in a template element, which are nice because their content is
+  // not rendered by browsers
+  if (domElement.nodeName.toLowerCase() === "template") {
+    // IE11 doesn't support the content property on templates
+    domElement = (domElement.content || domElement).querySelector(
+      "single-spa-router"
+    );
+  }
+
   if (domElement.nodeName.toLowerCase() !== "single-spa-router") {
     throw Error(
       `single-spa-layout: The HTMLElement passed to constructRoutes must be <single-spa-router>. Received ${domElement.nodeName}`


### PR DESCRIPTION
Browsers render the contents of `<single-spa-router>` by default, which is undesireable. That element is used to generated the routes, but shouldn't be rendered by the browser. Up until now, I've been using `display: none` as a workaround for this:

https://github.com/react-microfrontends/root-config/blob/7c4c143058aeeeedee07634fcbca20d91db1ba99/src/index.ejs#L25

However that looks a bit clunky and I think a more obvious solution is two wrap it in a `<template>` since those are hidden by the browser by default (except IE11, where you'll still have to do `display: "none"`

```html
<template id="single-spa-layout">
  <single-spa-router>
  </single-spa-router>
</template>
```

In this case, `document.querySelector('single-spa-router')` will return null, since the contents of template elements are in a separate document fragment. Instead, to get the single-spa-router element you have to do `constructRoutes(document.querySelector('#single-spa-layout').content.querySelector('single-spa-router'))`. However, that's a bit confusing/clunky as a public API, and gets harder since IE11 doesn't support the content property. So instead of requiring users to do that, I'm thinking we should support passing in a template object directly into constructRoutes: `constructRoutes(document.querySelector('#single-spa-layout'))`

This PR makes that possible.