### PR TITLE
Changing props API to allow case sensitive prop names. Resolves #43.

### DIFF
--- a/src/constructRoutes.js
+++ b/src/constructRoutes.js
@@ -48,6 +48,7 @@ import { find } from "./utils/find";
  * type: string;
  * path: string;
  * routes: Array<Route>;
+ * default?: boolean;
  * }} UrlRoute
  *
  * @typedef {{
@@ -179,7 +180,7 @@ function elementToJson(element, htmlLayoutData) {
         );
       }
     }
-    setProps(element, application, ["name", "loader"], htmlLayoutData);
+    setProps(element, application, htmlLayoutData);
     return [application];
   } else if (element.nodeName.toLowerCase() === "route") {
     const route = {
@@ -193,7 +194,7 @@ function elementToJson(element, htmlLayoutData) {
     if (hasAttribute(element, "default")) {
       route.default = true;
     }
-    setProps(element, route, ["path", "default"], htmlLayoutData);
+    setProps(element, route, htmlLayoutData);
     for (let i = 0; i < element.childNodes.length; i++) {
       route.routes.push(
         ...elementToJson(element.childNodes[i], htmlLayoutData)
@@ -236,30 +237,28 @@ function elementToJson(element, htmlLayoutData) {
 /**
  * @param {HTMLElement} element
  * @param {Route} route
- * @param {string[]} ignoredAttributes
  * @param {HTMLLayoutData} htmlLayoutData
  */
-function setProps(element, route, ignoredAttributes, htmlLayoutData) {
-  const attributes = element.attributes || element.attrs;
-  for (let i = 0; i < attributes.length; i++) {
-    const { name, value } = attributes[i];
-    if (ignoredAttributes.indexOf(name) >= 0) {
+function setProps(element, route, htmlLayoutData) {
+  const propNames = (getAttribute(element, "props") || "").split(",");
+
+  for (let i = 0; i < propNames.length; i++) {
+    const propName = propNames[i].trim();
+
+    if (propName.length === 0) {
       continue;
+    }
+
+    if (!route.props) {
+      route.props = {};
+    }
+
+    if (htmlLayoutData.props && htmlLayoutData.props.hasOwnProperty(propName)) {
+      route.props[propName] = htmlLayoutData.props[propName];
     } else {
-      if (!route.props) {
-        route.props = {};
-      }
-      const propName = value.trim() !== "" ? value : name;
-      if (
-        htmlLayoutData.props &&
-        htmlLayoutData.props.hasOwnProperty(propName)
-      ) {
-        route.props[name] = htmlLayoutData.props[propName];
-      } else {
-        throw Error(
-          `Prop '${name}' was not defined in the htmlLayoutData. Either remove this attribute from the HTML element or provide the prop's value`
-        );
-      }
+      throw Error(
+        `Prop '${propName}' was not defined in the htmlLayoutData. Either remove this attribute from the HTML element or provide the prop's value`
+      );
     }
   }
 }

--- a/test/constructRoutes.test.js
+++ b/test/constructRoutes.test.js
@@ -659,16 +659,19 @@ describe("constructRoutes", () => {
       const { document, routerElement } = parseFixture("props.html");
       const data = {
         props: {
+          mode: "client",
           portalMode: "client",
           prop1: "value1",
           prop2: "value2",
           prop3: "value3",
+          caseSensitiveProp: "value4",
         },
       };
       const routes = constructRoutes(routerElement, data);
       expect(routes.routes[0].props).toEqual({
-        mode: data.props.portalMode,
+        portalMode: data.props.portalMode,
         prop1: data.props.prop1,
+        caseSensitiveProp: "value4",
       });
       expect(routes.routes[1].routes[0].routes[0].props).toEqual({
         mode: data.props.portalMode,

--- a/test/fixtures/props.html
+++ b/test/fixtures/props.html
@@ -7,10 +7,13 @@
   </head>
   <body>
     <single-spa-router mode="history" base="/">
-      <application name="header" mode="portalMode" prop1></application>
+      <application
+        name="header"
+        props="portalMode,prop1,caseSensitiveProp"
+      ></application>
       <div class="main-content">
-        <route path="app1" prop3>
-          <application name="app1" mode="portalMode" prop2></application>
+        <route path="app1" props="prop3">
+          <application name="app1" props="mode,prop2"></application>
         </route>
       </div>
     </single-spa-router>


### PR DESCRIPTION
This is a breaking change. When designing the API for props, I overlooked how HTML attribute names are case insensitive.

**Before:**
`<application name="app1" prop1 prop2></application>`

**After:**
`<application name="app1" props="prop1,prop2"><application>`

Note that attribute *values* are case sensitive - just not their names.