### PR TITLE
fix: Retrieve containerEl attribute value from HTML tag when provided.

### DIFF
--- a/src/constructRoutes.js
+++ b/src/constructRoutes.js
@@ -123,6 +123,10 @@ function domToRoutesConfig(domElement, htmlLayoutData = {}) {
     result.base = getAttribute(domElement, "base");
   }
 
+  if (getAttribute(domElement, "containerEl")) {
+    result.containerEl = getAttribute(domElement, "containerEl");
+  }
+
   for (let i = 0; i < domElement.childNodes.length; i++) {
     result.routes.push(
       ...elementToJson(domElement.childNodes[i], htmlLayoutData)
@@ -138,7 +142,11 @@ function getAttribute(element, attrName) {
     return element.getAttribute(attrName);
   } else {
     // NodeJS with parse5
-    const attr = find(element.attrs, (attr) => attr.name === attrName);
+    // watch out, parse5 converts attribute names to lowercase and not as is => https://github.com/inikulin/parse5/issues/116
+    const attr = find(
+      element.attrs,
+      (attr) => attr.name === attrName.toLowerCase()
+    );
     return attr ? attr.value : null;
   }
 }

--- a/test/constructRoutes.test.js
+++ b/test/constructRoutes.test.js
@@ -704,4 +704,21 @@ describe("constructRoutes", () => {
       );
     });
   });
+
+  describe("router config defined in HTML", () => {
+    const { document, routerElement } = parseFixture("router-config.html");
+    const routes = constructRoutes(routerElement);
+
+    it(`assigns 'mode' when a valid value is passed as attribute`, () => {
+      expect(routes.mode).toBe("hash");
+    });
+
+    it(`assigns 'base' when a valid value is passed as attribute`, () => {
+      expect(routes.base).toBe("/custom/");
+    });
+
+    it(`assigns 'containerEl' when a valid value is passed as attribute`, () => {
+      expect(routes.containerEl).toBe("#spa-container");
+    });
+  });
 });

--- a/test/fixtures/router-config.html
+++ b/test/fixtures/router-config.html
@@ -1,0 +1,19 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Document</title>
+  </head>
+  <body>
+    <single-spa-router mode="hash" base="/custom" containerEl="#spa-container">
+      <application name="nav"></application>
+      <route path="clients">
+        <application name="clients"></application>
+      </route>
+      <route path="settings">
+        <application name="settings"></application>
+      </route>
+    </single-spa-router>
+  </body>
+</html>


### PR DESCRIPTION
### Changes

#### constructRoutes.js (Updated)
Retrieve the value of the containerEl-attribute using the method "getAttribute".
Changing the nodeJS path within "getAttribute" to use "toLowerCase" on "attrName" property to ensure it matches how parse5 parses HTML documents. 


#### constructRoutes.test.js (Updated)
Added 3 unit tests, for each attribute one, to test if the properties are handled when passed over HTML

#### router-config.html (Added)
Test fixture to test arguments passed over HTML

### Remarks / Considerations
I couldn't spot any tests related to the "containerEl" attribute within the browser-only section. Every tests seems to use the default 'body'. I as well couldn't figure out on the fast how and where to add some related tests. If requested I would figure it out and add some tests.