### PR TITLE
Fix double-rendering of applications and fragments in renderServerResponseBody

### DIFF
--- a/src/server/renderServerResponseBody.js
+++ b/src/server/renderServerResponseBody.js
@@ -96,7 +96,7 @@ function serializeChildNodes(args) {
       serialize = serializeRoute;
     } else if (isRouterContent(node)) {
       serialize = serializeRouterContent;
-    } else if (!inRouterElement && isFragmentNode(node)) {
+    } else if (isFragmentNode(node)) {
       serialize = serializeFragment;
     } else if (treeAdapter.isElementNode(node)) {
       serialize = serializeElement;

--- a/test/node-only/__snapshots__/renderServerResponseBody-node.test.js.snap
+++ b/test/node-only/__snapshots__/renderServerResponseBody-node.test.js.snap
@@ -33,14 +33,14 @@ exports[`renderServerResponseBody allows for strings to be returned from renderA
     <single-spa-router mode="history"
                        base="/"
     >
-      <div id="single-spa-application:undefined">
-      </div>
+      <application name="header">
+      </application>
       <div class="main-content">
         <button>
           Top level content
         </button>
-        <div id="single-spa-application:undefined">
-        </div>
+        <application name="app1">
+        </application>
         Some raw text
       </div>
       <span>
@@ -88,14 +88,14 @@ exports[`renderServerResponseBody dom-elements.html fixture renders the app1 rou
     <single-spa-router mode="history"
                        base="/"
     >
-      <div id="single-spa-application:undefined">
-      </div>
+      <application name="header">
+      </application>
       <div class="main-content">
         <button>
           Top level content
         </button>
-        <div id="single-spa-application:undefined">
-        </div>
+        <application name="app1">
+        </application>
         Some raw text
       </div>
       <span>


### PR DESCRIPTION
If you look at the snapshots, the bug is pretty clear. We should not actually call `renderApplication` for the `<application>` elements **within** the `<single-spa-router>` element, since the single-spa-router element needs to remain unchanged so that the browser can understand it. Note that single-spa-layout dynamically injects `<application>` elements outside of the single-spa-router element that are where the server rendered content goes.