### PR TITLE
Unmount loading UI when application fails to load.

### DIFF
--- a/src/browser/constructApplications.js
+++ b/src/browser/constructApplications.js
@@ -173,6 +173,8 @@ function placeLoader(appName, appRoute, loadingPromise) {
       },
       (err) => {
         return finishUp().then(() => {
+          // rethrow the error, so that the application's loading function
+          // remains in rejected status
           throw err;
         });
       }

--- a/src/browser/constructApplications.js
+++ b/src/browser/constructApplications.js
@@ -159,14 +159,23 @@ function placeLoader(appName, appRoute, loadingPromise) {
 
     applicationEl = applicationElement;
 
+    function finishUp() {
+      return parcel.unmount().then(() => {
+        if (makeElementVisible) {
+          makeElementVisible();
+        }
+      });
+    }
+
     return Promise.all([parcel.mountPromise, loadingPromise]).then(
-      ([mountResult, app]) =>
-        parcel.unmount().then(() => {
-          if (makeElementVisible) {
-            makeElementVisible();
-          }
-          return app;
-        })
+      ([mountResult, app]) => {
+        return finishUp().then(() => app);
+      },
+      (err) => {
+        return finishUp().then(() => {
+          throw err;
+        });
+      }
     );
   });
 }

--- a/test/constructApplications.test.js
+++ b/test/constructApplications.test.js
@@ -334,6 +334,65 @@ describe(`constructApplications`, () => {
     }
   });
 
+  it(`removes the loader if loading the application fails`, async () => {
+    const routes = constructRoutes({
+      routes: [
+        {
+          type: "application",
+          name: "app2",
+          loader: `<img src="loading.gif">`,
+        },
+      ],
+    });
+
+    const loadError = Error("could not download app code");
+
+    const loadApp = (name) =>
+      new Promise((resolve, reject) => {
+        setTimeout(() => {
+          reject(loadError);
+        }, 5);
+      });
+
+    const applications = constructApplications({ routes, loadApp });
+    let appEl;
+
+    if (inBrowser) {
+      appEl = document.getElementById(`single-spa-application:app2`);
+      expect(appEl).toBeNull();
+    }
+
+    // begin loading the app
+    const loadPromise = applications[0].app();
+
+    await tick();
+
+    if (inBrowser) {
+      appEl = document.getElementById(`single-spa-application:app2`);
+      expect(appEl).toMatchInlineSnapshot(`
+        <div
+          id="single-spa-application:app2"
+          style="display: none;"
+        >
+          <img
+            src="loading.gif"
+          />
+        </div>
+      `);
+    }
+
+    expect(await loadPromise.catch((err) => err)).toBe(loadError);
+
+    if (inBrowser) {
+      appEl = document.getElementById(`single-spa-application:app2`);
+      expect(appEl).toMatchInlineSnapshot(`
+        <div
+          id="single-spa-application:app2"
+        />
+      `);
+    }
+  });
+
   // https://github.com/single-spa/single-spa-layout/issues/64
   it(`does not require trailing slashes after base path`, () => {
     const routes = constructRoutes({

--- a/test/constructApplications.test.js
+++ b/test/constructApplications.test.js
@@ -381,7 +381,8 @@ describe(`constructApplications`, () => {
       `);
     }
 
-    expect(await loadPromise.catch((err) => err)).toBe(loadError);
+    expect(loadPromise).rejects.toThrow(loadError);
+    await Promise.allSettled([loadPromise]);
 
     if (inBrowser) {
       appEl = document.getElementById(`single-spa-application:app2`);


### PR DESCRIPTION
In investigating #84, I came across a separate bug from what was described in that issue. The bug is that the loading UI keeps showing after an application fails to load. This PR fixes things so that that's not the case.