### PR TITLE
Rethrow errors inside of error handler. Resolves #88.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,9 +1,10 @@
 {
   "extends": "important-stuff",
   "parser": "babel-eslint",
-  "plugins": [
-    "es5"
-  ],
+  "plugins": ["es5"],
+  "globals": {
+    "process": true
+  },
   "rules": {
     "es5/no-es6-methods": "error",
     "es5/no-es6-static-methods": "error",

--- a/package.json
+++ b/package.json
@@ -78,6 +78,7 @@
     "@rollup/plugin-babel": "^5.2.1",
     "@rollup/plugin-commonjs": "^15.1.0",
     "@rollup/plugin-node-resolve": "^9.0.0",
+    "@rollup/plugin-replace": "^2.3.4",
     "@testing-library/dom": "^7.24.3",
     "@testing-library/jest-dom": "^5.11.4",
     "@types/jest": "^26.0.14",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -3,6 +3,7 @@ import babel from "@rollup/plugin-babel";
 import fs from "fs";
 import { nodeResolve } from "@rollup/plugin-node-resolve";
 import commonjs from "@rollup/plugin-commonjs";
+import replace from "@rollup/plugin-replace";
 
 const packageJson = JSON.parse(fs.readFileSync("./package.json"));
 
@@ -37,6 +38,9 @@ function createConfig(format, server = false) {
       nodeResolve(),
       commonjs(),
       babel(babelOpts),
+      replace({
+        "process.env.BABEL_ENV": JSON.stringify("production"),
+      }),
       process.env.DEVELOPMENT !== "true" &&
         terser({
           compress: {

--- a/src/browser/constructLayoutEngine.js
+++ b/src/browser/constructLayoutEngine.js
@@ -121,6 +121,10 @@ export function constructLayoutEngine({
         }
       );
     }
+
+    setTimeout(() => {
+      throw err;
+    });
   }
 
   function unmountErrorParcels({ detail: { newAppStatuses } }) {

--- a/src/browser/constructLayoutEngine.js
+++ b/src/browser/constructLayoutEngine.js
@@ -122,9 +122,11 @@ export function constructLayoutEngine({
       );
     }
 
-    setTimeout(() => {
-      throw err;
-    });
+    if (process.env.BABEL_ENV !== "test") {
+      setTimeout(() => {
+        throw err;
+      });
+    }
   }
 
   function unmountErrorParcels({ detail: { newAppStatuses } }) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1474,6 +1474,14 @@
     is-module "^1.0.0"
     resolve "^1.17.0"
 
+"@rollup/plugin-replace@^2.3.4":
+  version "2.3.4"
+  resolved "https://registry.yarnpkg.com/@rollup/plugin-replace/-/plugin-replace-2.3.4.tgz#7dd84c17755d62b509577f2db37eb524d7ca88ca"
+  integrity sha512-waBhMzyAtjCL1GwZes2jaE9MjuQ/DQF2BatH3fRivUF3z0JBFrU0U6iBNC/4WR+2rLKhaAhPWDNPYp4mI6RqdQ==
+  dependencies:
+    "@rollup/pluginutils" "^3.1.0"
+    magic-string "^0.25.7"
+
 "@rollup/pluginutils@^3.1.0":
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-3.1.0.tgz#706b4524ee6dc8b103b3c995533e5ad680c02b9b"


### PR DESCRIPTION
See #88. The cause is that single-spa doesn't throw errors if there are error handlers, and single-spa-layout introduces an error handler. The fix is to have the single-spa-layout error handler rethrow the error.