### PR TITLE
Reuse application containers during DOM move operations. Resolves #115.

### DIFF
--- a/src/browser/constructLayoutEngine.js
+++ b/src/browser/constructLayoutEngine.js
@@ -181,6 +181,7 @@ export function constructLayoutEngine({
         ? document.querySelector(resolvedRoutes.containerEl)
         : resolvedRoutes.containerEl;
 
+    // We need to move, not destroy + recreate, application container elements
     const applicationContainers = getMountedApps().reduce(
       (applicationContainers, appName) => {
         applicationContainers[appName] = document.getElementById(


### PR DESCRIPTION
See #115. In single-spa-layout@1.3.0, we'd remove dom elements after finishing mounting all dom elements. This helped us ensure the same application container element would be moved to the correct part of the DOM, instead of destroyed and recreated. However, in #112 this was changed such that dom elements are mounted at the same time that dom elements are mounted, to avoid flicker of weird content. In doing so, I didn't ensure that the application container element was moved before its parent container was removed from the DOM.

The fix here retrieves all applicationContainer elements upfront before any mounting/unmounting has been done. It then moves those container elements around instead of letting them be destroyed when the parent container is destroyed.