### PR TITLE
Fix strToLocation in modern browsers.

### DIFF
--- a/src/browser/constructLayoutEngine.js
+++ b/src/browser/constructLayoutEngine.js
@@ -426,7 +426,7 @@ function getPath(resolvedRoutes, l = location) {
 
 function strToLocation(str) {
   try {
-    new URL(str);
+    return new URL(str);
   } catch (err) {
     // IE11
     const a = document.createElement("a");


### PR DESCRIPTION
This fixes a regression bug introduced by 06aa9ab9d9277d4356a92550483dec523e25ac49