### PR TITLE
Avoid unnecessary appendChild and insertBefore calls. Resolves #123.

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,6 +1,6 @@
 {
   "extends": "important-stuff",
-  "parser": "babel-eslint",
+  "parser": "@babel/eslint-parser",
   "plugins": ["es5"],
   "globals": {
     "process": true

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
   ],
   "devDependencies": {
     "@babel/core": "^7.11.6",
+    "@babel/eslint-parser": "^7.13.14",
     "@babel/plugin-transform-modules-commonjs": "^7.10.4",
     "@babel/preset-env": "^7.11.5",
     "@rollup/plugin-babel": "^5.2.1",
@@ -84,7 +85,6 @@
     "@types/jest": "^26.0.14",
     "@types/jsdom": "^16.2.4",
     "@types/systemjs": "^6.1.0",
-    "babel-eslint": "^11.0.0-beta.2",
     "babel-jest": "^26.3.0",
     "concurrently": "^5.3.0",
     "cross-env": "^7.0.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,9 +1,55 @@
+lockfileVersion: 5.3
+
+specifiers:
+  "@babel/core": ^7.11.6
+  "@babel/eslint-parser": ^7.13.14
+  "@babel/plugin-transform-modules-commonjs": ^7.10.4
+  "@babel/preset-env": ^7.11.5
+  "@rollup/plugin-babel": ^5.2.1
+  "@rollup/plugin-commonjs": ^15.1.0
+  "@rollup/plugin-node-resolve": ^9.0.0
+  "@rollup/plugin-replace": ^2.3.4
+  "@testing-library/dom": ^7.29.4
+  "@testing-library/jest-dom": ^5.11.4
+  "@types/jest": ^26.0.14
+  "@types/jsdom": ^16.2.4
+  "@types/parse5": ^5.0.3
+  "@types/systemjs": ^6.1.0
+  babel-jest: ^26.3.0
+  concurrently: ^5.3.0
+  cross-env: ^7.0.2
+  cypress: ^5.2.0
+  eslint: ^7.10.0
+  eslint-config-important-stuff: ^1.1.0
+  eslint-config-node-important-stuff: ^1.1.0
+  eslint-plugin-es5: ^1.5.0
+  husky: ^4.3.0
+  jest: ^26.4.2
+  jest-cli: ^26.4.2
+  jest-serializer-html: ^7.0.0
+  js-correct-lockfile: ^1.0.0
+  jsdom: ^16.4.0
+  ls-exports: ^1.0.2
+  merge2: ^1.4.1
+  parse5: ^6.0.1
+  prettier: ^2.1.2
+  pretty-quick: ^3.0.2
+  rimraf: ^3.0.2
+  rollup: ^2.28.2
+  rollup-cli: ^1.0.9
+  rollup-plugin-terser: ^7.0.2
+  single-spa: ^5.9.0
+  tsd: ^0.13.1
+  typescript: ^4.0.3
+
 dependencies:
   "@types/parse5": 5.0.3
   merge2: 1.4.1
   parse5: 6.0.1
+
 devDependencies:
   "@babel/core": 7.12.10
+  "@babel/eslint-parser": 7.13.14_b5d2baead2359fee426c65690feab125
   "@babel/plugin-transform-modules-commonjs": 7.12.1_@babel+core@7.12.10
   "@babel/preset-env": 7.12.11_@babel+core@7.12.10
   "@rollup/plugin-babel": 5.2.2_ef0fb8bb075dad5ddd10a028b31f2344
@@ -15,7 +61,6 @@ devDependencies:
   "@types/jest": 26.0.20
   "@types/jsdom": 16.2.6
   "@types/systemjs": 6.1.0
-  babel-eslint: 11.0.0-beta.2_b5d2baead2359fee426c65690feab125
   babel-jest: 26.6.3_@babel+core@7.12.10
   concurrently: 5.3.0
   cross-env: 7.0.3
@@ -40,19 +85,30 @@ devDependencies:
   single-spa: 5.9.0
   tsd: 0.13.1
   typescript: 4.1.3
-lockfileVersion: 5.2
+
 packages:
   /@babel/code-frame/7.12.11:
+    resolution:
+      {
+        integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==,
+      }
     dependencies:
       "@babel/highlight": 7.10.4
     dev: true
-    resolution:
-      integrity: sha512-Zt1yodBx1UcyiePMSkWnU4hPqhwq7hGi2nFL1LeA3EUl+q2LQx16MISgJ0+z7dnmgvP9QtIleuETGOiOH1RcIw==
+
   /@babel/compat-data/7.12.7:
-    dev: true
     resolution:
-      integrity: sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==
+      {
+        integrity: sha512-YaxPMGs/XIWtYqrdEOZOCPsVWfEoriXopnsz3/i7apYPXQ3698UFhS6dVT1KN5qOsWmVgw/FOrmQgpRaZayGsw==,
+      }
+    dev: true
+
   /@babel/core/7.12.10:
+    resolution:
+      {
+        integrity: sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==,
+      }
+    engines: { node: ">=6.9.0" }
     dependencies:
       "@babel/code-frame": 7.12.11
       "@babel/generator": 7.12.11
@@ -69,33 +125,64 @@ packages:
       lodash: 4.17.20
       semver: 5.7.1
       source-map: 0.5.7
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">=6.9.0"
+
+  /@babel/eslint-parser/7.13.14_b5d2baead2359fee426c65690feab125:
     resolution:
-      integrity: sha512-eTAlQKq65zHfkHZV0sIVODCPGVgoo1HdBlbSLi9CqOzuZanMv2ihzY+4paiKr1mH+XmYESMAmJ/dpZ68eN6d8w==
+      {
+        integrity: sha512-I0HweR36D73Ibn/FfrRDMKlMqJHFwidIUgYdMpH+aXYuQC+waq59YaJ6t9e9N36axJ82v1jR041wwqDrDXEwRA==,
+      }
+    engines: { node: ^10.13.0 || ^12.13.0 || >=14.0.0 }
+    peerDependencies:
+      "@babel/core": ">=7.11.0"
+      eslint: ">=7.5.0"
+    dependencies:
+      "@babel/core": 7.12.10
+      eslint: 7.18.0
+      eslint-scope: 5.1.1
+      eslint-visitor-keys: 1.3.0
+      semver: 6.3.0
+    dev: true
+
   /@babel/generator/7.12.11:
+    resolution:
+      {
+        integrity: sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==,
+      }
     dependencies:
       "@babel/types": 7.12.12
       jsesc: 2.5.2
       source-map: 0.5.7
     dev: true
-    resolution:
-      integrity: sha512-Ggg6WPOJtSi8yYQvLVjG8F/TlpWDlKx0OpS4Kt+xMQPs5OaGYWy+v1A+1TvxI6sAMGZpKWWoAQ1DaeQbImlItA==
+
   /@babel/helper-annotate-as-pure/7.12.10:
+    resolution:
+      {
+        integrity: sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==,
+      }
     dependencies:
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-XplmVbC1n+KY6jL8/fgLVXXUauDIB+lD5+GsQEh6F6GBF1dq1qy4DP4yXWzDKcoqXB3X58t61e85Fitoww4JVQ==
+
   /@babel/helper-builder-binary-assignment-operator-visitor/7.10.4:
+    resolution:
+      {
+        integrity: sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==,
+      }
     dependencies:
       "@babel/helper-explode-assignable-expression": 7.12.1
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-L0zGlFrGWZK4PbT8AszSfLTM5sDU1+Az/En9VrdT8/LmEiJt4zXt+Jve9DCAnQcbqDhCI+29y/L93mrDzddCcg==
+
   /@babel/helper-compilation-targets/7.12.5_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0
     dependencies:
       "@babel/compat-data": 7.12.7
       "@babel/core": 7.12.10
@@ -103,11 +190,14 @@ packages:
       browserslist: 4.16.1
       semver: 5.7.1
     dev: true
+
+  /@babel/helper-create-class-features-plugin/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0
-    resolution:
-      integrity: sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==
-  /@babel/helper-create-class-features-plugin/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-function-name": 7.12.11
@@ -115,68 +205,95 @@ packages:
       "@babel/helper-optimise-call-expression": 7.12.10
       "@babel/helper-replace-supers": 7.12.11
       "@babel/helper-split-export-declaration": 7.12.11
+    transitivePeerDependencies:
+      - supports-color
     dev: true
+
+  /@babel/helper-create-regexp-features-plugin/7.12.7_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0
-    resolution:
-      integrity: sha512-hkL++rWeta/OVOBTRJc9a5Azh5mt5WgZUGAKMD8JM141YsE08K//bp1unBBieO6rUKkIPyUE0USQ30jAy3Sk1w==
-  /@babel/helper-create-regexp-features-plugin/7.12.7_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-annotate-as-pure": 7.12.10
       regexpu-core: 4.7.1
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0
-    resolution:
-      integrity: sha512-idnutvQPdpbduutvi3JVfEgcVIHooQnhvhx0Nk9isOINOIGYkZea1Pk2JlJRiUnMefrlvr0vkByATBY/mB4vjQ==
+
   /@babel/helper-define-map/7.10.5:
+    resolution:
+      {
+        integrity: sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==,
+      }
     dependencies:
       "@babel/helper-function-name": 7.12.11
       "@babel/types": 7.12.12
       lodash: 4.17.20
     dev: true
-    resolution:
-      integrity: sha512-fMw4kgFB720aQFXSVaXr79pjjcW5puTCM16+rECJ/plGS+zByelE8l9nCpV1GibxTnFVmUuYG9U8wYfQHdzOEQ==
+
   /@babel/helper-explode-assignable-expression/7.12.1:
+    resolution:
+      {
+        integrity: sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==,
+      }
     dependencies:
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-dmUwH8XmlrUpVqgtZ737tK88v07l840z9j3OEhCLwKTkjlvKpfqXVIZ0wpK3aeOxspwGrf/5AP5qLx4rO3w5rA==
+
   /@babel/helper-function-name/7.12.11:
+    resolution:
+      {
+        integrity: sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==,
+      }
     dependencies:
       "@babel/helper-get-function-arity": 7.12.10
       "@babel/template": 7.12.7
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-AtQKjtYNolKNi6nNNVLQ27CP6D9oFR6bq/HPYSizlzbp7uC1M59XJe8L+0uXjbIaZaUJF99ruHqVGiKXU/7ybA==
+
   /@babel/helper-get-function-arity/7.12.10:
+    resolution:
+      {
+        integrity: sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==,
+      }
     dependencies:
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-mm0n5BPjR06wh9mPQaDdXWDoll/j5UpCAPl1x8fS71GHm7HA6Ua2V4ylG1Ju8lvcTOietbPNNPaSilKj+pj+Ag==
+
   /@babel/helper-hoist-variables/7.10.4:
+    resolution:
+      {
+        integrity: sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==,
+      }
     dependencies:
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-wljroF5PgCk2juF69kanHVs6vrLwIPNp6DLD+Lrl3hoQ3PpPPikaDRNFA+0t81NOoMt2DL6WW/mdU8k4k6ZzuA==
+
   /@babel/helper-member-expression-to-functions/7.12.7:
+    resolution:
+      {
+        integrity: sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==,
+      }
     dependencies:
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-DCsuPyeWxeHgh1Dus7APn7iza42i/qXqiFPWyBDdOFtvS581JQePsc1F/nD+fHrcswhLlRc2UpYS1NwERxZhHw==
+
   /@babel/helper-module-imports/7.12.5:
+    resolution:
+      {
+        integrity: sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==,
+      }
     dependencies:
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
+
   /@babel/helper-module-transforms/7.12.1:
+    resolution:
+      {
+        integrity: sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==,
+      }
     dependencies:
       "@babel/helper-module-imports": 7.12.5
       "@babel/helper-replace-supers": 7.12.11
@@ -187,394 +304,547 @@ packages:
       "@babel/traverse": 7.12.12
       "@babel/types": 7.12.12
       lodash: 4.17.20
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    resolution:
-      integrity: sha512-QQzehgFAZ2bbISiCpmVGfiGux8YVFXQ0abBic2Envhej22DVXV9nCFaS5hIQbkyo1AdGb+gNME2TSh3hYJVV/w==
+
   /@babel/helper-optimise-call-expression/7.12.10:
+    resolution:
+      {
+        integrity: sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==,
+      }
     dependencies:
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-4tpbU0SrSTjjt65UMWSrUOPZTsgvPgGG4S8QSTNHacKzpS51IVWGDj0yCwyeZND/i+LSN2g/O63jEXEWm49sYQ==
+
   /@babel/helper-plugin-utils/7.10.4:
-    dev: true
     resolution:
-      integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==
+      {
+        integrity: sha512-O4KCvQA6lLiMU9l2eawBPMf1xPP8xPfB3iEQw150hOVTqj/rfXz0ThTb4HEzqQfs2Bmo5Ay8BzxfzVtBrr9dVg==,
+      }
+    dev: true
+
   /@babel/helper-remap-async-to-generator/7.12.1:
+    resolution:
+      {
+        integrity: sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==,
+      }
     dependencies:
       "@babel/helper-annotate-as-pure": 7.12.10
       "@babel/helper-wrap-function": 7.12.3
       "@babel/types": 7.12.12
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    resolution:
-      integrity: sha512-9d0KQCRM8clMPcDwo8SevNs+/9a8yWVVmaE80FGJcEP8N1qToREmWEGnBn8BUlJhYRFz6fqxeRL1sl5Ogsed7A==
+
   /@babel/helper-replace-supers/7.12.11:
+    resolution:
+      {
+        integrity: sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==,
+      }
     dependencies:
       "@babel/helper-member-expression-to-functions": 7.12.7
       "@babel/helper-optimise-call-expression": 7.12.10
       "@babel/traverse": 7.12.12
       "@babel/types": 7.12.12
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    resolution:
-      integrity: sha512-q+w1cqmhL7R0FNzth/PLLp2N+scXEK/L2AHbXUyydxp828F4FEa5WcVoqui9vFRiHDQErj9Zof8azP32uGVTRA==
+
   /@babel/helper-simple-access/7.12.1:
+    resolution:
+      {
+        integrity: sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==,
+      }
     dependencies:
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-OxBp7pMrjVewSSC8fXDFrHrBcJATOOFssZwv16F3/6Xtc138GHybBfPbm9kfiqQHKhYQrlamWILwlDCeyMFEaA==
+
   /@babel/helper-skip-transparent-expression-wrappers/7.12.1:
+    resolution:
+      {
+        integrity: sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==,
+      }
     dependencies:
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-Mf5AUuhG1/OCChOJ/HcADmvcHM42WJockombn8ATJG3OnyiSxBK/Mm5x78BQWvmtXZKHgbjdGL2kin/HOLlZGA==
+
   /@babel/helper-split-export-declaration/7.12.11:
+    resolution:
+      {
+        integrity: sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==,
+      }
     dependencies:
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-LsIVN8j48gHgwzfocYUSkO/hjYAOJqlpJEc7tGXcIm4cubjVUf8LGW6eWRyxEu7gA25q02p0rQUWoCI33HNS5g==
+
   /@babel/helper-validator-identifier/7.12.11:
-    dev: true
     resolution:
-      integrity: sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==
+      {
+        integrity: sha512-np/lG3uARFybkoHokJUmf1QfEvRVCPbmQeUQpKow5cQ3xWrV9i3rUHodKDJPQfTVX61qKi+UdYk8kik84n7XOw==,
+      }
+    dev: true
+
   /@babel/helper-validator-option/7.12.11:
-    dev: true
     resolution:
-      integrity: sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw==
+      {
+        integrity: sha512-TBFCyj939mFSdeX7U7DDj32WtzYY7fDcalgq8v3fBZMNOJQNn7nOYzMaUCiPxPYfCup69mtIpqlKgMZLvQ8Xhw==,
+      }
+    dev: true
+
   /@babel/helper-wrap-function/7.12.3:
+    resolution:
+      {
+        integrity: sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==,
+      }
     dependencies:
       "@babel/helper-function-name": 7.12.11
       "@babel/template": 7.12.7
       "@babel/traverse": 7.12.12
       "@babel/types": 7.12.12
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    resolution:
-      integrity: sha512-Cvb8IuJDln3rs6tzjW3Y8UeelAOdnpB8xtQ4sme2MSZ9wOxrbThporC0y/EtE16VAtoyEfLM404Xr1e0OOp+ow==
+
   /@babel/helpers/7.12.5:
+    resolution:
+      {
+        integrity: sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==,
+      }
     dependencies:
       "@babel/template": 7.12.7
       "@babel/traverse": 7.12.12
       "@babel/types": 7.12.12
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    resolution:
-      integrity: sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==
+
   /@babel/highlight/7.10.4:
+    resolution:
+      {
+        integrity: sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==,
+      }
     dependencies:
       "@babel/helper-validator-identifier": 7.12.11
       chalk: 2.4.2
       js-tokens: 4.0.0
     dev: true
-    resolution:
-      integrity: sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==
+
   /@babel/parser/7.12.11:
-    dev: true
-    engines:
-      node: ">=6.0.0"
-    hasBin: true
     resolution:
-      integrity: sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==
+      {
+        integrity: sha512-N3UxG+uuF4CMYoNj8AhnbAcJF0PiuJ9KHuy1lQmkYsxTer/MAH9UBNHsBoAX/4s6NvlDD047No8mYVGGzLL4hg==,
+      }
+    engines: { node: ">=6.0.0" }
+    hasBin: true
+    dev: true
+
   /@babel/plugin-proposal-async-generator-functions/7.12.12_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-nrz9y0a4xmUrRq51bYkWJIO5SBZyG2ys2qinHsN0zHDHVsUaModrkpyWWWXfGqYQmOL3x9sQIcTNN/pBGpo09A==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/helper-remap-async-to-generator": 7.12.1
       "@babel/plugin-syntax-async-generators": 7.8.4_@babel+core@7.12.10
+    transitivePeerDependencies:
+      - supports-color
     dev: true
+
+  /@babel/plugin-proposal-class-properties/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-nrz9y0a4xmUrRq51bYkWJIO5SBZyG2ys2qinHsN0zHDHVsUaModrkpyWWWXfGqYQmOL3x9sQIcTNN/pBGpo09A==
-  /@babel/plugin-proposal-class-properties/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-create-class-features-plugin": 7.12.1_@babel+core@7.12.10
       "@babel/helper-plugin-utils": 7.10.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
+
+  /@babel/plugin-proposal-dynamic-import/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-cKp3dlQsFsEs5CWKnN7BnSHOd0EOW8EKpEjkoz1pO2E5KzIDNV9Ros1b0CnmbVgAGXJubOYVBOGCT1OmJwOI7w==
-  /@babel/plugin-proposal-dynamic-import/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/plugin-syntax-dynamic-import": 7.8.3_@babel+core@7.12.10
     dev: true
+
+  /@babel/plugin-proposal-export-namespace-from/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-a4rhUSZFuq5W8/OO8H7BL5zspjnc1FLd9hlOxIK/f7qG4a0qsqk8uvF/ywgBA8/OmjsapjpvaEOYItfGG1qIvQ==
-  /@babel/plugin-proposal-export-namespace-from/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/plugin-syntax-export-namespace-from": 7.8.3_@babel+core@7.12.10
     dev: true
+
+  /@babel/plugin-proposal-json-strings/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-6CThGf0irEkzujYS5LQcjBx8j/4aQGiVv7J9+2f7pGfxqyKh3WnmVJYW3hdrQjyksErMGBPQrCnHfOtna+WLbw==
-  /@babel/plugin-proposal-json-strings/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/plugin-syntax-json-strings": 7.8.3_@babel+core@7.12.10
     dev: true
+
+  ? /@babel/plugin-proposal-logical-assignment-operators/7.12.1_@babel+core@7.12.10
+  : resolution:
+      {
+        integrity: sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-GoLDUi6U9ZLzlSda2Df++VSqDJg3CG+dR0+iWsv6XRw1rEq+zwt4DirM9yrxW6XWaTpmai1cWJLMfM8qQJf+yw==
-  ? /@babel/plugin-proposal-logical-assignment-operators/7.12.1_@babel+core@7.12.10
-  : dependencies:
+    dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/plugin-syntax-logical-assignment-operators": 7.10.4_@babel+core@7.12.10
     dev: true
+
+  ? /@babel/plugin-proposal-nullish-coalescing-operator/7.12.1_@babel+core@7.12.10
+  : resolution:
+      {
+        integrity: sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-k8ZmVv0JU+4gcUGeCDZOGd0lCIamU/sMtIiX3UWnUc5yzgq6YUGyEolNYD+MLYKfSzgECPcqetVcJP9Afe/aCA==
-  ? /@babel/plugin-proposal-nullish-coalescing-operator/7.12.1_@babel+core@7.12.10
-  : dependencies:
+    dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/plugin-syntax-nullish-coalescing-operator": 7.8.3_@babel+core@7.12.10
     dev: true
+
+  /@babel/plugin-proposal-numeric-separator/7.12.7_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-nZY0ESiaQDI1y96+jk6VxMOaL4LPo/QDHBqL+SF3/vl6dHkTwHlOI8L4ZwuRBHgakRBw5zsVylel7QPbbGuYgg==
-  /@babel/plugin-proposal-numeric-separator/7.12.7_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/plugin-syntax-numeric-separator": 7.10.4_@babel+core@7.12.10
     dev: true
+
+  /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-8c+uy0qmnRTeukiGsjLGy6uVs/TFjJchGXUeBqlG4VWYOdJWkhhVPdQ3uHwbmalfJwv2JsV0qffXP4asRfL2SQ==
-  /@babel/plugin-proposal-object-rest-spread/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/plugin-syntax-object-rest-spread": 7.8.3_@babel+core@7.12.10
       "@babel/plugin-transform-parameters": 7.12.1_@babel+core@7.12.10
     dev: true
+
+  /@babel/plugin-proposal-optional-catch-binding/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-s6SowJIjzlhx8o7lsFx5zmY4At6CTtDvgNQDdPzkBQucle58A6b/TTeEBYtyDgmcXjUTM+vE8YOGHZzzbc/ioA==
-  /@babel/plugin-proposal-optional-catch-binding/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/plugin-syntax-optional-catch-binding": 7.8.3_@babel+core@7.12.10
     dev: true
+
+  /@babel/plugin-proposal-optional-chaining/7.12.7_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-hFvIjgprh9mMw5v42sJWLI1lzU5L2sznP805zeT6rySVRA0Y18StRhDqhSxlap0oVgItRsB6WSROp4YnJTJz0g==
-  /@babel/plugin-proposal-optional-chaining/7.12.7_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/helper-skip-transparent-expression-wrappers": 7.12.1
       "@babel/plugin-syntax-optional-chaining": 7.8.3_@babel+core@7.12.10
     dev: true
+
+  /@babel/plugin-proposal-private-methods/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-4ovylXZ0PWmwoOvhU2vhnzVNnm88/Sm9nx7V8BPgMvAzn5zDou3/Awy0EjglyubVHasJj+XCEkr/r1X3P5elCA==
-  /@babel/plugin-proposal-private-methods/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-create-class-features-plugin": 7.12.1_@babel+core@7.12.10
       "@babel/helper-plugin-utils": 7.10.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
+
+  /@babel/plugin-proposal-unicode-property-regex/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==,
+      }
+    engines: { node: ">=4" }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-mwZ1phvH7/NHK6Kf8LP7MYDogGV+DKB1mryFOEwx5EBNQrosvIczzZFTUmWaeujd5xT6G1ELYWUz3CutMhjE1w==
-  /@babel/plugin-proposal-unicode-property-regex/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-create-regexp-features-plugin": 7.12.7_@babel+core@7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    engines:
-      node: ">=4"
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-MYq+l+PvHuw/rKUz1at/vb6nCnQ2gmJBNaM62z0OgH7B2W1D9pvkpYtlti9bGtizNIU1K3zm4bZF9F91efVY0w==
+
   /@babel/plugin-syntax-async-generators/7.8.4_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-tycmZxkGfZaxhMRbXlPXuVFpdWlXpir2W4AMhSJgRKzk/eDlIXOhb2LHWoLpDF7TEHylV5zNhykX6KAgHJmTNw==
+
   /@babel/plugin-syntax-bigint/7.8.3_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-wnTnFlG+YxQm3vDxpGE57Pj0srRU4sHE/mDkt1qv2YJJSeUAec2ma4WLUnUPeKjyrfntVwe/N6dCXpU+zL3Npg==
+
   /@babel/plugin-syntax-class-properties/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-U40A76x5gTwmESz+qiqssqmeEsKvcSyvtgktrm0uzcARAmM9I1jR221f6Oq+GmHrcD+LvZDag1UTOTe2fL3TeA==
+
   /@babel/plugin-syntax-dynamic-import/7.8.3_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-5gdGbFon+PszYzqs83S3E5mpi7/y/8M9eC90MRTZfduQOYW76ig6SOSPNe41IG5LoP3FGBn2N0RjVDSQiS94kQ==
+
   /@babel/plugin-syntax-export-namespace-from/7.8.3_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-MXf5laXo6c1IbEbegDmzGPwGNTsHZmEy6QGznu5Sh2UCWvueywb2ee+CCE4zQiZstxU9BMoQO9i6zUFSY0Kj0Q==
+
   /@babel/plugin-syntax-import-meta/7.10.4_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-Yqfm+XDx0+Prh3VSeEQCPU81yC+JWZ2pDPFSS4ZdpfZhp4MkFMaDC1UqseovEKwSUpnIL7+vK+Clp7bfh0iD7g==
+
   /@babel/plugin-syntax-json-strings/7.8.3_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-lY6kdGpWHvjoe2vk4WrAapEuBR69EMxZl+RoGRhrFGNYVK8mOPAW8VfbT/ZgrFbXlDNiiaxQnAtgVCZ6jv30EA==
+
   /@babel/plugin-syntax-logical-assignment-operators/7.10.4_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-d8waShlpFDinQ5MtvGU9xDAOzKH47+FFoney2baFIoMr952hKOLp1HR7VszoZvOsV/4+RRszNY7D17ba0te0ig==
+
   /@babel/plugin-syntax-nullish-coalescing-operator/7.8.3_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-aSff4zPII1u2QD7y+F8oDsz19ew4IGEJg9SVW+bqwpwtfFleiQDMdzA/R+UlWDzfnHFCxxleFT0PMIrR36XLNQ==
+
   /@babel/plugin-syntax-numeric-separator/7.10.4_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-9H6YdfkcK/uOnY/K7/aA2xpzaAgkQn37yzWUMRK7OaPOqOpGS1+n0H5hxT9AUw9EsSjPW8SVyMJwYRtWs3X3ug==
+
   /@babel/plugin-syntax-object-rest-spread/7.8.3_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-XoqMijGZb9y3y2XskN+P1wUGiVwWZ5JmoDRwx5+3GmEplNyVM2s2Dg8ILFQm8rWM48orGy5YpI5Bl8U1y7ydlA==
+
   /@babel/plugin-syntax-optional-catch-binding/7.8.3_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-6VPD0Pc1lpTqw0aKoeRTMiB+kWhAoT24PA+ksWSBrFtl5SIRVpZlwN3NNPQjehA2E/91FV3RjLWoVTglWcSV3Q==
+
   /@babel/plugin-syntax-optional-chaining/7.8.3_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-KoK9ErH1MBlCPxV0VANkXW2/dw4vlbGDrFgz8bmUsBGYkFRcbRwMh6cIJubdPrkxRwuGdtCk0v/wPTKbQgBjkg==
+
   /@babel/plugin-syntax-top-level-await/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-i7ooMZFS+a/Om0crxZodrTzNEPJHZrlMVGMTEpFAj6rYY/bKCddB0Dk/YxfPuYXOopuhKk/e1jV6h+WUU9XN3A==
+
   /@babel/plugin-transform-arrow-functions/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-async-to-generator/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-5QB50qyN44fzzz4/qxDPQMBCTHgxg3n0xRBLJUmBlLoU/sFvxVWGZF/ZUfMVDQuJUKXaBhbupxIzIfZ6Fwk/0A==
-  /@babel/plugin-transform-async-to-generator/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-module-imports": 7.12.5
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/helper-remap-async-to-generator": 7.12.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-SDtqoEcarK1DFlRJ1hHRY5HvJUj5kX4qmtpMAm2QnhOlyuMC4TMdCRgW6WXpv93rZeYNeLP22y8Aq2dbcDRM1A==
+
   /@babel/plugin-transform-block-scoped-functions/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-5OpxfuYnSgPalRpo8EWGPzIYf0lHBWORCkj5M0oLBwHdlux9Ri36QqGW3/LR13RSVOAoUUMzoPI/jpE4ABcHoA==
+
   /@babel/plugin-transform-block-scoping/7.12.12_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-classes/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-VOEPQ/ExOVqbukuP7BYJtI5ZxxsmegTwzZ04j1aF0dkSypGo9XpDHuOrABsJu+ie+penpSJheDJ11x1BEZNiyQ==
-  /@babel/plugin-transform-classes/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-annotate-as-pure": 7.12.10
@@ -585,119 +855,161 @@ packages:
       "@babel/helper-replace-supers": 7.12.11
       "@babel/helper-split-export-declaration": 7.12.11
       globals: 11.12.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-/74xkA7bVdzQTBeSUhLLJgYIcxw/dpEpCdRDiHgPJ3Mv6uC11UhjpOhl72CgqbBCmt1qtssCyB2xnJm1+PFjog==
+
   /@babel/plugin-transform-computed-properties/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-vVUOYpPWB7BkgUWPo4C44mUQHpTZXakEqFjbv8rQMg7TC6S6ZhGZ3otQcRH6u7+adSlE5i0sp63eMC/XGffrzg==
+
   /@babel/plugin-transform-destructuring/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-dotall-regex/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-fRMYFKuzi/rSiYb2uRLiUENJOKq4Gnl+6qOv5f8z0TZXg3llUwUhsNNwrwaT/6dUhJTzNpBr+CUvEWBtfNY1cw==
-  /@babel/plugin-transform-dotall-regex/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-create-regexp-features-plugin": 7.12.7_@babel+core@7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-duplicate-keys/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-B2pXeRKoLszfEW7J4Hg9LoFaWEbr/kzo3teWHmtFCszjRNa/b40f9mfeqZsIDLLt/FjwQ6pz/Gdlwy85xNckBA==
-  /@babel/plugin-transform-duplicate-keys/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-exponentiation-operator/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-iRght0T0HztAb/CazveUpUQrZY+aGKKaWXMJ4uf9YJtqxSUe09j3wteztCUDRHs+SRAL7yMuFqUsLoAKKzgXjw==
-  /@babel/plugin-transform-exponentiation-operator/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-builder-binary-assignment-operator-visitor": 7.10.4
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-for-of/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-7tqwy2bv48q+c1EHbXK0Zx3KXd2RVQp6OC7PbwFNt/dPTAV3Lu5sWtWuAj8owr5wqtWnqHfl2/mJlUmqkChKug==
-  /@babel/plugin-transform-for-of/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-function-name/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-Zaeq10naAsuHo7heQvyV0ptj4dlZJwZgNAtBYBnu5nNKJoW62m0zKcIEyVECrUKErkUkg6ajMy4ZfnVZciSBhg==
-  /@babel/plugin-transform-function-name/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-function-name": 7.12.11
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-literals/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-JF3UgJUILoFrFMEnOJLJkRHSk6LUSXLmEFsA23aR2O5CSLUxbeUX1IZ1YQ7Sn0aXb601Ncwjx73a+FVqgcljVw==
-  /@babel/plugin-transform-literals/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  ? /@babel/plugin-transform-member-expression-literals/7.12.1_@babel+core@7.12.10
+  : resolution:
+      {
+        integrity: sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-+PxVGA+2Ag6uGgL0A5f+9rklOnnMccwEBzwYFL3EUaKuiyVnUipyXncFcfjSkbimLrODoqki1U9XxZzTvfN7IQ==
-  ? /@babel/plugin-transform-member-expression-literals/7.12.1_@babel+core@7.12.10
-  : dependencies:
+    dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-modules-amd/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-1sxePl6z9ad0gFMB9KqmYofk34flq62aqMt9NqliS/7hPEpURUCMbyHXrMPlo282iY7nAvUB1aQd5mg79UD9Jg==
-  /@babel/plugin-transform-modules-amd/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-module-transforms": 7.12.1
       "@babel/helper-plugin-utils": 7.10.4
       babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
+
+  /@babel/plugin-transform-modules-commonjs/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-tDW8hMkzad5oDtzsB70HIQQRBiTKrhfgwC/KkJeGsaNFTdWhKNt/BiE8c5yj19XiGyrxpbkOfH87qkNg1YGlOQ==
-  /@babel/plugin-transform-modules-commonjs/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-module-transforms": 7.12.1
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/helper-simple-access": 7.12.1
       babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
+
+  /@babel/plugin-transform-modules-systemjs/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-dY789wq6l0uLY8py9c1B48V8mVL5gZh/+PQ5ZPrylPYsnAvnEMjqsUXkuoDVPeVK+0VyGar+D08107LzDQ6pag==
-  /@babel/plugin-transform-modules-systemjs/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-hoist-variables": 7.10.4
@@ -705,151 +1017,205 @@ packages:
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/helper-validator-identifier": 7.12.11
       babel-plugin-dynamic-import-node: 2.3.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
+
+  /@babel/plugin-transform-modules-umd/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-Hn7cVvOavVh8yvW6fLwveFqSnd7rbQN3zJvoPNyNaQSvgfKmDBO9U1YL9+PCXGRlZD9tNdWTy5ACKqMuzyn32Q==
-  /@babel/plugin-transform-modules-umd/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-module-transforms": 7.12.1
       "@babel/helper-plugin-utils": 7.10.4
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-aEIubCS0KHKM0zUos5fIoQm+AZUMt1ZvMpqz0/H5qAQ7vWylr9+PLYurT+Ic7ID/bKLd4q8hDovaG3Zch2uz5Q==
+
   ? /@babel/plugin-transform-named-capturing-groups-regex/7.12.1_@babel+core@7.12.10
-  : dependencies:
+  : resolution:
+      {
+        integrity: sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0
+    dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-create-regexp-features-plugin": 7.12.7_@babel+core@7.12.10
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0
-    resolution:
-      integrity: sha512-tB43uQ62RHcoDp9v2Nsf+dSM8sbNodbEicbQNA53zHz8pWUhsgHSJCGpt7daXxRydjb0KnfmB+ChXOv3oADp1Q==
+
   /@babel/plugin-transform-new-target/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-object-super/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-+eW/VLcUL5L9IvJH7rT1sT0CzkdUTvPrXC2PXTn/7z7tXLBuKvezYbGdxD5WMRoyvyaujOq2fWoKl869heKjhw==
-  /@babel/plugin-transform-object-super/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/helper-replace-supers": 7.12.11
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-AvypiGJH9hsquNUn+RXVcBdeE3KHPZexWRdimhuV59cSoOt5kFBmqlByorAeUlGG2CJWd0U+4ZtNKga/TB0cAw==
+
   /@babel/plugin-transform-parameters/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-xq9C5EQhdPK23ZeCdMxl8bbRnAgHFrw5EOC3KJUsSylZqdkCaFEXxGSBuTSObOpiiHHNyb82es8M1QYgfQGfNg==
+
   /@babel/plugin-transform-property-literals/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-regenerator/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-6MTCR/mZ1MQS+AwZLplX4cEySjCpnIF26ToWo942nqn8hXSm7McaHQNeGx/pt7suI1TWOWMfa/NgBhiqSnX0cQ==
-  /@babel/plugin-transform-regenerator/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       regenerator-transform: 0.14.5
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-gYrHqs5itw6i4PflFX3OdBPMQdPbF4bj2REIUxlMRUFk0/ZOAIpDFuViuxPjUL7YC8UPnf+XG7/utJvqXdPKng==
+
   /@babel/plugin-transform-reserved-words/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-pOnUfhyPKvZpVyBHhSBoX8vfA09b7r00Pmm1sH+29ae2hMTKVmSp4Ztsr8KBKjLjx17H0eJqaRC3bR2iThM54A==
+
   /@babel/plugin-transform-shorthand-properties/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-spread/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-GFZS3c/MhX1OusqB1MZ1ct2xRzX5ppQh2JU1h2Pnfk88HtFTM+TWQqJNfwkmxtPQtb/s1tk87oENfXJlx7rSDw==
-  /@babel/plugin-transform-spread/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
       "@babel/helper-skip-transparent-expression-wrappers": 7.12.1
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-vuLp8CP0BE18zVYjsEBZ5xoCecMK6LBMMxYzJnh01rxQRvhNhH1csMMmBfNo5tGpGO+NhdSNW2mzIvBu3K1fng==
+
   /@babel/plugin-transform-sticky-regex/7.12.7_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-VEiqZL5N/QvDbdjfYQBhruN0HYjSPjC4XkeqW4ny/jNtH9gcbgaqBIXYEZCNnESMAGs0/K/R7oFGMhOyu/eIxg==
+
   /@babel/plugin-transform-template-literals/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-b4Zx3KHi+taXB1dVRBhVJtEPi9h1THCeKmae2qP0YdUHIFhVjtpqqNfxeVAa1xeHVhAy4SbHxEwx5cltAu5apw==
+
   /@babel/plugin-transform-typeof-symbol/7.12.10_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-JQ6H8Rnsogh//ijxspCjc21YPd3VLVoYtAwv3zQmqAt8YGYUtdo5usNhdl4b9/Vir2kPFZl6n1h0PfUz4hJhaA==
+
   /@babel/plugin-transform-unicode-escapes/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0-0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/plugin-transform-unicode-regex/7.12.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-I8gNHJLIc7GdApm7wkVnStWssPNbSRMPtgHdmH3sRM1zopz09UWPS4x5V4n1yz/MIWTVnJ9sp6IkuXdWM4w+2Q==
-  /@babel/plugin-transform-unicode-regex/7.12.1_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-create-regexp-features-plugin": 7.12.7_@babel+core@7.12.10
       "@babel/helper-plugin-utils": 7.10.4
     dev: true
+
+  /@babel/preset-env/7.12.11_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-SqH4ClNngh/zGwHZOOQMTD+e8FGWexILV+ePMyiDJttAWRh5dhDL8rcl5lSgU3Huiq6Zn6pWTMvdPAb21Dwdyg==
-  /@babel/preset-env/7.12.11_@babel+core@7.12.10:
     dependencies:
       "@babel/compat-data": 7.12.7
       "@babel/core": 7.12.10
@@ -918,12 +1284,17 @@ packages:
       "@babel/types": 7.12.12
       core-js-compat: 3.8.3
       semver: 5.7.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
+
+  /@babel/preset-modules/0.1.4_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==,
+      }
     peerDependencies:
       "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-j8Tb+KKIXKYlDBQyIOy4BLxzv1NUOwlHfZ74rvW+Z0Gp4/cI2IMDPBWAgWceGcE7aep9oL/0K9mlzlMGxA8yNw==
-  /@babel/preset-modules/0.1.4_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       "@babel/helper-plugin-utils": 7.10.4
@@ -932,32 +1303,42 @@ packages:
       "@babel/types": 7.12.12
       esutils: 2.0.3
     dev: true
-    peerDependencies:
-      "@babel/core": ^7.0.0-0
-    resolution:
-      integrity: sha512-J36NhwnfdzpmH41M1DrnkkgAqhZaqr/NBdPfQ677mLzlaXo+oDiv1deyCDtgAhz8p328otdob0Du7+xgHGZbKg==
+
   /@babel/runtime-corejs3/7.12.5:
+    resolution:
+      {
+        integrity: sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==,
+      }
     dependencies:
       core-js-pure: 3.8.3
       regenerator-runtime: 0.13.7
     dev: true
-    resolution:
-      integrity: sha512-roGr54CsTmNPPzZoCP1AmDXuBoNao7tnSA83TXTwt+UK5QVyh1DIJnrgYRPWKCF2flqZQXwa7Yr8v7VmLzF0YQ==
+
   /@babel/runtime/7.12.5:
+    resolution:
+      {
+        integrity: sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==,
+      }
     dependencies:
       regenerator-runtime: 0.13.7
     dev: true
-    resolution:
-      integrity: sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
+
   /@babel/template/7.12.7:
+    resolution:
+      {
+        integrity: sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==,
+      }
     dependencies:
       "@babel/code-frame": 7.12.11
       "@babel/parser": 7.12.11
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-GkDzmHS6GV7ZeXfJZ0tLRBhZcMcY0/Lnb+eEbXDBfCAcZCjrZKe6p3J4we/D24O9Y8enxWAg1cWwof59yLh2ow==
+
   /@babel/traverse/7.12.12:
+    resolution:
+      {
+        integrity: sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==,
+      }
     dependencies:
       "@babel/code-frame": 7.12.11
       "@babel/generator": 7.12.11
@@ -968,43 +1349,56 @@ packages:
       debug: 4.3.1
       globals: 11.12.0
       lodash: 4.17.20
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    resolution:
-      integrity: sha512-s88i0X0lPy45RrLM8b9mz8RPH5FqO9G9p7ti59cToE44xFm1Q+Pjh5Gq4SXBbtb88X7Uy7pexeqRIQDDMNkL0w==
+
   /@babel/types/7.12.12:
+    resolution:
+      {
+        integrity: sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==,
+      }
     dependencies:
       "@babel/helper-validator-identifier": 7.12.11
       lodash: 4.17.20
       to-fast-properties: 2.0.0
     dev: true
-    resolution:
-      integrity: sha512-lnIX7piTxOH22xE7fDXDbSHg9MM1/6ORnafpJmov5rs0kX5g4BZxeXNJLXsMRiO0U5Rb8/FvMS6xlTnTHvxonQ==
+
   /@bcoe/v8-coverage/0.2.3:
-    dev: true
     resolution:
-      integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
+      {
+        integrity: sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==,
+      }
+    dev: true
+
   /@cnakazawa/watch/1.0.4:
+    resolution:
+      {
+        integrity: sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==,
+      }
+    engines: { node: ">=0.1.95" }
+    hasBin: true
     dependencies:
       exec-sh: 0.3.4
       minimist: 1.2.5
     dev: true
-    engines:
-      node: ">=0.1.95"
-    hasBin: true
-    resolution:
-      integrity: sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==
+
   /@cypress/listr-verbose-renderer/0.4.1:
+    resolution: { integrity: sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo= }
+    engines: { node: ">=4" }
     dependencies:
       chalk: 1.1.3
       cli-cursor: 1.0.2
       date-fns: 1.30.1
       figures: 1.7.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-p3SS9LEdzHxEajSz4ochr9M8ZCo=
+
   /@cypress/request/2.88.5:
+    resolution:
+      {
+        integrity: sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==,
+      }
+    engines: { node: ">= 6" }
     dependencies:
       aws-sign2: 0.7.0
       aws4: 1.11.0
@@ -1027,18 +1421,23 @@ packages:
       tunnel-agent: 0.6.0
       uuid: 3.4.0
     dev: true
-    engines:
-      node: ">= 6"
-    resolution:
-      integrity: sha512-TzEC1XMi1hJkywWpRfD2clreTa/Z+lOrXDCxxBTBPEcY5azdPi56A6Xw+O4tWJnaJH3iIE7G5aDXZC6JgRZLcA==
+
   /@cypress/xvfb/1.2.4:
+    resolution:
+      {
+        integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==,
+      }
     dependencies:
       debug: 3.2.7
       lodash.once: 4.1.1
     dev: true
-    resolution:
-      integrity: sha512-skbBzPggOVYCbnGgV+0dmBdW/s77ZkAOXIC1knS8NagwDjBrNC1LuXtQJeiN6l+m7lzmHtaoUw/ctJKdqkG57Q==
+
   /@eslint/eslintrc/0.3.0:
+    resolution:
+      {
+        integrity: sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==,
+      }
+    engines: { node: ^10.12.0 || >=12.0.0 }
     dependencies:
       ajv: 6.12.6
       debug: 4.3.1
@@ -1050,12 +1449,16 @@ packages:
       lodash: 4.17.20
       minimatch: 3.0.4
       strip-json-comments: 3.1.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    resolution:
-      integrity: sha512-1JTKgrOKAHVivSvOYw+sJOunkBjUOvjqWk1DPja7ZFhIS2mX/4EgTT8M7eTK9jrKhL/FvXXEbQwIs3pg1xp3dg==
+
   /@istanbuljs/load-nyc-config/1.1.0:
+    resolution:
+      {
+        integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       camelcase: 5.3.1
       find-up: 4.1.0
@@ -1063,17 +1466,21 @@ packages:
       js-yaml: 3.14.1
       resolve-from: 5.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-VjeHSlIzpv/NyD3N0YuHfXOPDIixcA1q2ZV98wsMqcYlPmv2n3Yb2lYP9XMElnaFVXg5A7YLTeLu6V84uQDjmQ==
+
   /@istanbuljs/schema/0.1.2:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==
+      {
+        integrity: sha512-tsAQNx32a8CoFhjhijUIhI4kccIAgmGhy8LZMZgGfmXcpMbPRUqn5LWmgRttILi6yeGmBJd2xsPkFMs0PzgPCw==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /@jest/console/26.6.2:
+    resolution:
+      {
+        integrity: sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/types": 26.6.2
       "@types/node": 14.14.22
@@ -1082,11 +1489,13 @@ packages:
       jest-util: 26.6.2
       slash: 3.0.0
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-IY1R2i2aLsLr7Id3S6p2BA82GNWryt4oSvEXLAKc+L2zdi89dSkE8xC1C+0kpATG4JhBJREnQOH7/zmccM2B0g==
+
   /@jest/core/26.6.3:
+    resolution:
+      {
+        integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/console": 26.6.2
       "@jest/reporters": 26.6.2
@@ -1116,23 +1525,33 @@ packages:
       rimraf: 3.0.2
       slash: 3.0.0
       strip-ansi: 6.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-xvV1kKbhfUqFVuZ8Cyo+JPpipAHHAV3kcDBftiduK8EICXmTFddryy3P7NfZt8Pv37rA9nEJBKCCkglCPt/Xjw==
+
   /@jest/environment/26.6.2:
+    resolution:
+      {
+        integrity: sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/fake-timers": 26.6.2
       "@jest/types": 26.6.2
       "@types/node": 14.14.22
       jest-mock: 26.6.2
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-nFy+fHl28zUrRsCeMB61VDThV1pVTtlEokBRgqPrcT1JNq4yRNIyTHfyht6PqtUvY9IsuLGTrbG8kPXjSZIZwA==
+
   /@jest/fake-timers/26.6.2:
+    resolution:
+      {
+        integrity: sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/types": 26.6.2
       "@sinonjs/fake-timers": 6.0.1
@@ -1141,21 +1560,25 @@ packages:
       jest-mock: 26.6.2
       jest-util: 26.6.2
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-14Uleatt7jdzefLPYM3KLcnUl1ZNikaKq34enpb5XG9i81JpppDb5muZvonvKyrl7ftEHkKS5L5/eB/kxJ+bvA==
+
   /@jest/globals/26.6.2:
+    resolution:
+      {
+        integrity: sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/environment": 26.6.2
       "@jest/types": 26.6.2
       expect: 26.6.2
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-85Ltnm7HlB/KesBUuALwQ68YTU72w9H2xW9FjZ1eL1U3lhtefjjl5c2MiUbpXt/i6LaPRvoOFJ22yCBSfQ0JIA==
+
   /@jest/reporters/26.6.2:
+    resolution:
+      {
+        integrity: sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@bcoe/v8-coverage": 0.2.3
       "@jest/console": 26.6.2
@@ -1181,47 +1604,63 @@ packages:
       string-length: 4.0.1
       terminal-link: 2.1.1
       v8-to-istanbul: 7.1.0
-    dev: true
-    engines:
-      node: ">= 10.14.2"
     optionalDependencies:
       node-notifier: 8.0.1
-    resolution:
-      integrity: sha512-h2bW53APG4HvkOnVMo8q3QXa6pcaNt1HkwVsOPMBV6LD/q9oSpxNSYZQYkAnjdMjrJ86UuYeLo+aEZClV6opnw==
+    transitivePeerDependencies:
+      - supports-color
+    dev: true
+
   /@jest/source-map/26.6.2:
+    resolution:
+      {
+        integrity: sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       callsites: 3.1.0
       graceful-fs: 4.2.4
       source-map: 0.6.1
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-YwYcCwAnNmOVsZ8mr3GfnzdXDAl4LaenZP5z+G0c8bzC9/dugL8zRmxZzdoTl4IaS3CryS1uWnROLPFmb6lVvA==
+
   /@jest/test-result/26.6.2:
+    resolution:
+      {
+        integrity: sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/console": 26.6.2
       "@jest/types": 26.6.2
       "@types/istanbul-lib-coverage": 2.0.3
       collect-v8-coverage: 1.0.1
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-5O7H5c/7YlojphYNrK02LlDIV2GNPYisKwHm2QTKjNZeEzezCbwYs9swJySv2UfPMyZ0VdsmMv7jIlD/IKYQpQ==
+
   /@jest/test-sequencer/26.6.3:
+    resolution:
+      {
+        integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/test-result": 26.6.2
       graceful-fs: 4.2.4
       jest-haste-map: 26.6.2
       jest-runner: 26.6.3
       jest-runtime: 26.6.3
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-YHlVIjP5nfEyjlrSr8t/YdNfU/1XEt7c5b4OxcXCjyRhjzLYu/rO69/WHPuYcbCWkz8kAeZVZp2N2+IOLLEPGw==
+
   /@jest/transform/26.6.2:
+    resolution:
+      {
+        integrity: sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@babel/core": 7.12.10
       "@jest/types": 26.6.2
@@ -1238,12 +1677,16 @@ packages:
       slash: 3.0.0
       source-map: 0.6.1
       write-file-atomic: 3.0.3
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-E9JjhUgNzvuQ+vVAL21vlyfy12gP0GhazGgJC4h6qUt1jSdUXGWJ1wfu/X7Sd8etSgxV4ovT1pb9v5D6QW4XgA==
+
   /@jest/types/26.6.2:
+    resolution:
+      {
+        integrity: sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@types/istanbul-lib-coverage": 2.0.3
       "@types/istanbul-reports": 3.0.0
@@ -1251,39 +1694,49 @@ packages:
       "@types/yargs": 15.0.12
       chalk: 4.1.0
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-fC6QCp7Sc5sX6g8Tvbmj4XUTbyrik0akgRy03yjXbQaBWWNWGE7SGtJk98m0N8nzegD/7SggrUlivxo5ax4KWQ==
+
   /@nodelib/fs.scandir/2.1.4:
+    resolution:
+      {
+        integrity: sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==,
+      }
+    engines: { node: ">= 8" }
     dependencies:
       "@nodelib/fs.stat": 2.0.4
       run-parallel: 1.1.10
     dev: true
-    engines:
-      node: ">= 8"
-    resolution:
-      integrity: sha512-33g3pMJk3bg5nXbL/+CY6I2eJDzZAni49PfJnL5fghPTggPvBd/pFNSgJsdAgWptuFu7qq/ERvOYFlhvsLTCKA==
+
   /@nodelib/fs.stat/2.0.4:
-    dev: true
-    engines:
-      node: ">= 8"
     resolution:
-      integrity: sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==
+      {
+        integrity: sha512-IYlHJA0clt2+Vg7bccq+TzRdJvv19c2INqBSsoOLp1je7xjtr7J26+WXR72MCdvU9q1qTzIWDfhMf+DRvQJK4Q==,
+      }
+    engines: { node: ">= 8" }
+    dev: true
+
   /@nodelib/fs.walk/1.2.6:
+    resolution:
+      {
+        integrity: sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==,
+      }
+    engines: { node: ">= 8" }
     dependencies:
       "@nodelib/fs.scandir": 2.1.4
       fastq: 1.10.0
     dev: true
-    engines:
-      node: ">= 8"
-    resolution:
-      integrity: sha512-8Broas6vTtW4GIXTAHDoE32hnN2M5ykgCpWGbuXHQ15vEMqr23pB76e/GZcYsZCHALv50ktd24qhEyKr6wBtow==
+
   /@npmcli/ci-detect/1.3.0:
-    dev: true
     resolution:
-      integrity: sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==
+      {
+        integrity: sha512-oN3y7FAROHhrAt7Rr7PnTSwrHrZVRTS2ZbyxeQwSSYD0ifwM3YNgQqbaRmjcWoPyq77MjchusjJDspbzMmip1Q==,
+      }
+    dev: true
+
   /@npmcli/git/2.0.4:
+    resolution:
+      {
+        integrity: sha512-OJZCmJ9DNn1cz9HPXXsPmUBnqaArot3CGYo63CyajHQk+g87rPXVOJByGsskQJhPsUUEXJcsZ2Q6bWd2jSwnBA==,
+      }
     dependencies:
       "@npmcli/promise-spawn": 1.3.2
       lru-cache: 6.0.0
@@ -1295,40 +1748,53 @@ packages:
       unique-filename: 1.1.1
       which: 2.0.2
     dev: true
-    resolution:
-      integrity: sha512-OJZCmJ9DNn1cz9HPXXsPmUBnqaArot3CGYo63CyajHQk+g87rPXVOJByGsskQJhPsUUEXJcsZ2Q6bWd2jSwnBA==
+
   /@npmcli/installed-package-contents/1.0.5:
+    resolution:
+      {
+        integrity: sha512-aKIwguaaqb6ViwSOFytniGvLPb9SMCUm39TgM3SfUo7n0TxUMbwoXfpwyvQ4blm10lzbAwTsvjr7QZ85LvTi4A==,
+      }
+    engines: { node: ">= 10" }
+    hasBin: true
     dependencies:
       npm-bundled: 1.1.1
       npm-normalize-package-bin: 1.0.1
       read-package-json-fast: 1.2.1
       readdir-scoped-modules: 1.1.0
     dev: true
-    engines:
-      node: ">= 10"
-    hasBin: true
-    resolution:
-      integrity: sha512-aKIwguaaqb6ViwSOFytniGvLPb9SMCUm39TgM3SfUo7n0TxUMbwoXfpwyvQ4blm10lzbAwTsvjr7QZ85LvTi4A==
+
   /@npmcli/move-file/1.1.0:
+    resolution:
+      {
+        integrity: sha512-Iv2iq0JuyYjKeFkSR4LPaCdDZwlGK9X2cP/01nJcp3yMJ1FjNd9vpiEYvLUgzBxKPg2SFmaOhizoQsPc0LWeOQ==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       mkdirp: 1.0.4
       rimraf: 2.7.1
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-Iv2iq0JuyYjKeFkSR4LPaCdDZwlGK9X2cP/01nJcp3yMJ1FjNd9vpiEYvLUgzBxKPg2SFmaOhizoQsPc0LWeOQ==
+
   /@npmcli/node-gyp/1.0.1:
-    dev: true
     resolution:
-      integrity: sha512-pBqoKPWmuk9iaEcXlLBVRIA6I1kG9JiICU+sG0NuD6NAR461F+02elHJS4WkQxHW2W5rnsfvP/ClKwmsZ9RaaA==
+      {
+        integrity: sha512-pBqoKPWmuk9iaEcXlLBVRIA6I1kG9JiICU+sG0NuD6NAR461F+02elHJS4WkQxHW2W5rnsfvP/ClKwmsZ9RaaA==,
+      }
+    dev: true
+
   /@npmcli/promise-spawn/1.3.2:
+    resolution:
+      {
+        integrity: sha512-QyAGYo/Fbj4MXeGdJcFzZ+FkDkomfRBrPM+9QYJSg+PxgAUL+LU3FneQk37rKR2/zjqkCV1BLHccX98wRXG3Sg==,
+      }
     dependencies:
       infer-owner: 1.0.4
     dev: true
-    resolution:
-      integrity: sha512-QyAGYo/Fbj4MXeGdJcFzZ+FkDkomfRBrPM+9QYJSg+PxgAUL+LU3FneQk37rKR2/zjqkCV1BLHccX98wRXG3Sg==
+
   /@npmcli/run-script/1.8.1:
+    resolution:
+      {
+        integrity: sha512-G8c86g9cQHyRINosIcpovzv0BkXQc3urhL1ORf3KTe4TS4UBsg2O4Z2feca/W3pfzdHEJzc83ETBW4aKbb3SaA==,
+      }
     dependencies:
       "@npmcli/node-gyp": 1.0.1
       "@npmcli/promise-spawn": 1.3.2
@@ -1337,17 +1803,13 @@ packages:
       puka: 1.0.1
       read-package-json-fast: 1.2.1
     dev: true
-    resolution:
-      integrity: sha512-G8c86g9cQHyRINosIcpovzv0BkXQc3urhL1ORf3KTe4TS4UBsg2O4Z2feca/W3pfzdHEJzc83ETBW4aKbb3SaA==
+
   /@rollup/plugin-babel/5.2.2_ef0fb8bb075dad5ddd10a028b31f2344:
-    dependencies:
-      "@babel/core": 7.12.10
-      "@babel/helper-module-imports": 7.12.5
-      "@rollup/pluginutils": 3.1.0_rollup@2.38.0
-      rollup: 2.38.0
-    dev: true
-    engines:
-      node: ">= 10.0.0"
+    resolution:
+      {
+        integrity: sha512-MjmH7GvFT4TW8xFdIeFS3wqIX646y5tACdxkTO+khbHvS3ZcVJL6vkAHLw2wqPmkhwCfWHoNsp15VYNwW6JEJA==,
+      }
+    engines: { node: ">= 10.0.0" }
     peerDependencies:
       "@babel/core": ^7.0.0
       "@types/babel__core": ^7.1.9
@@ -1355,9 +1817,21 @@ packages:
     peerDependenciesMeta:
       "@types/babel__core":
         optional: true
-    resolution:
-      integrity: sha512-MjmH7GvFT4TW8xFdIeFS3wqIX646y5tACdxkTO+khbHvS3ZcVJL6vkAHLw2wqPmkhwCfWHoNsp15VYNwW6JEJA==
+    dependencies:
+      "@babel/core": 7.12.10
+      "@babel/helper-module-imports": 7.12.5
+      "@rollup/pluginutils": 3.1.0_rollup@2.38.0
+      rollup: 2.38.0
+    dev: true
+
   /@rollup/plugin-commonjs/15.1.0_rollup@2.38.0:
+    resolution:
+      {
+        integrity: sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==,
+      }
+    engines: { node: ">= 8.0.0" }
+    peerDependencies:
+      rollup: ^2.22.0
     dependencies:
       "@rollup/pluginutils": 3.1.0_rollup@2.38.0
       commondir: 1.0.1
@@ -1368,13 +1842,15 @@ packages:
       resolve: 1.19.0
       rollup: 2.38.0
     dev: true
-    engines:
-      node: ">= 8.0.0"
-    peerDependencies:
-      rollup: ^2.22.0
-    resolution:
-      integrity: sha512-xCQqz4z/o0h2syQ7d9LskIMvBSH4PX5PjYdpSSvgS+pQik3WahkQVNWg3D8XJeYjZoVWnIUQYDghuEMRGrmQYQ==
+
   /@rollup/plugin-node-resolve/9.0.0_rollup@2.38.0:
+    resolution:
+      {
+        integrity: sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==,
+      }
+    engines: { node: ">= 10.0.0" }
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
     dependencies:
       "@rollup/pluginutils": 3.1.0_rollup@2.38.0
       "@types/resolve": 1.17.1
@@ -1384,42 +1860,41 @@ packages:
       resolve: 1.19.0
       rollup: 2.38.0
     dev: true
-    engines:
-      node: ">= 10.0.0"
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0
-    resolution:
-      integrity: sha512-gPz+utFHLRrd41WMP13Jq5mqqzHL3OXrfj3/MkSyB6UBIcuNt9j60GCbarzMzdf1VHFpOxfQh/ez7wyadLMqkg==
+
   /@rollup/plugin-replace/2.3.4_rollup@2.38.0:
+    resolution:
+      {
+        integrity: sha512-waBhMzyAtjCL1GwZes2jaE9MjuQ/DQF2BatH3fRivUF3z0JBFrU0U6iBNC/4WR+2rLKhaAhPWDNPYp4mI6RqdQ==,
+      }
+    peerDependencies:
+      rollup: ^1.20.0 || ^2.0.0
     dependencies:
       "@rollup/pluginutils": 3.1.0_rollup@2.38.0
       magic-string: 0.25.7
       rollup: 2.38.0
     dev: true
-    peerDependencies:
-      rollup: ^1.20.0 || ^2.0.0
-    resolution:
-      integrity: sha512-waBhMzyAtjCL1GwZes2jaE9MjuQ/DQF2BatH3fRivUF3z0JBFrU0U6iBNC/4WR+2rLKhaAhPWDNPYp4mI6RqdQ==
+
   /@rollup/pluginutils/3.1.0_rollup@2.38.0:
+    resolution:
+      {
+        integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==,
+      }
+    engines: { node: ">= 8.0.0" }
+    peerDependencies:
+      rollup: ^1.20.0||^2.0.0
     dependencies:
       "@types/estree": 0.0.39
       estree-walker: 1.0.1
       picomatch: 2.2.2
       rollup: 2.38.0
     dev: true
-    engines:
-      node: ">= 8.0.0"
-    peerDependencies:
-      rollup: ^1.20.0||^2.0.0
-    resolution:
-      integrity: sha512-GksZ6pr6TpIjHm8h9lSQ8pi8BE9VeubNT0OMJ3B5uZJ8pz73NPiqOtCog/x2/QzM1ENChPKxMDhiQuRHsqc+lg==
+
   /@samverschueren/stream-to-observable/0.3.1_rxjs@6.6.3:
-    dependencies:
-      any-observable: 0.3.0
-      rxjs: 6.6.3
-    dev: true
-    engines:
-      node: ">=6"
+    resolution:
+      {
+        integrity: sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==,
+      }
+    engines: { node: ">=6" }
     peerDependencies:
       rxjs: "*"
       zen-observable: "*"
@@ -1428,35 +1903,53 @@ packages:
         optional: true
       zen-observable:
         optional: true
-    resolution:
-      integrity: sha512-c/qwwcHyafOQuVQJj0IlBjf5yYgBI7YPJ77k4fOJYesb41jio65eaJODRUmfYKhTOFBrIZ66kgvGPlNbjuoRdQ==
-  /@sindresorhus/is/0.14.0:
+    dependencies:
+      any-observable: 0.3.0
+      rxjs: 6.6.3
     dev: true
-    engines:
-      node: ">=6"
+
+  /@sindresorhus/is/0.14.0:
     resolution:
-      integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==
+      {
+        integrity: sha512-9NET910DNaIPngYnLLPeg+Ogzqsi9uM4mSboU5y6p8S5DzMTVEsJZrawi+BoDNUVBa2DhJqQYUFvMDfgU062LQ==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /@sinonjs/commons/1.8.2:
+    resolution:
+      {
+        integrity: sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==,
+      }
     dependencies:
       type-detect: 4.0.8
     dev: true
-    resolution:
-      integrity: sha512-sruwd86RJHdsVf/AtBoijDmUqJp3B6hF/DGC23C+JaegnDHaZyewCjoVGTdg3J0uz3Zs7NnIT05OBOmML72lQw==
+
   /@sinonjs/fake-timers/6.0.1:
+    resolution:
+      {
+        integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==,
+      }
     dependencies:
       "@sinonjs/commons": 1.8.2
     dev: true
-    resolution:
-      integrity: sha512-MZPUxrmFubI36XS1DI3qmI0YdN1gks62JtFZvxR67ljjSNCeK6U08Zx4msEWOXuofgqUt6zPHSi1H9fbjR/NRA==
+
   /@szmarczak/http-timer/1.1.2:
+    resolution:
+      {
+        integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       defer-to-connect: 1.1.3
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-XIB2XbzHTN6ieIjfIMV9hlVcfPU26s2vafYWQcZHWXHOxiaRZYEDKEwdl129Zyg50+foYV2jCgtrqSA6qNuNSA==
+
   /@testing-library/dom/7.29.4:
+    resolution:
+      {
+        integrity: sha512-CtrJRiSYEfbtNGtEsd78mk1n1v2TUbeABlNIcOCJdDfkN5/JTOwQEbbQpoSRxGqzcWPgStMvJ4mNolSuBRv1NA==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       "@babel/code-frame": 7.12.11
       "@babel/runtime": 7.12.5
@@ -1467,11 +1960,13 @@ packages:
       lz-string: 1.4.4
       pretty-format: 26.6.2
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-CtrJRiSYEfbtNGtEsd78mk1n1v2TUbeABlNIcOCJdDfkN5/JTOwQEbbQpoSRxGqzcWPgStMvJ4mNolSuBRv1NA==
+
   /@testing-library/jest-dom/5.11.9:
+    resolution:
+      {
+        integrity: sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==,
+      }
+    engines: { node: ">=8", npm: ">=6", yarn: ">=1" }
     dependencies:
       "@babel/runtime": 7.12.5
       "@types/testing-library__jest-dom": 5.9.5
@@ -1482,23 +1977,27 @@ packages:
       lodash: 4.17.20
       redent: 3.0.0
     dev: true
-    engines:
-      node: ">=8"
-      npm: ">=6"
-      yarn: ">=1"
-    resolution:
-      integrity: sha512-Mn2gnA9d1wStlAIT2NU8J15LNob0YFBVjs2aEQ3j8rsfRQo+lAs7/ui1i2TGaJjapLmuNPLTsrm+nPjmZDwpcQ==
+
   /@tootallnate/once/1.1.2:
-    dev: true
-    engines:
-      node: ">= 6"
     resolution:
-      integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+      {
+        integrity: sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==,
+      }
+    engines: { node: ">= 6" }
+    dev: true
+
   /@types/aria-query/4.2.1:
-    dev: true
     resolution:
-      integrity: sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==
+      {
+        integrity: sha512-S6oPal772qJZHoRZLFc/XoZW2gFvwXusYUmXPXkgxJLuEk2vOt7jc4Yo6z/vtI0EBkbPBVrJJ0B+prLIKiWqHg==,
+      }
+    dev: true
+
   /@types/babel__core/7.1.12:
+    resolution:
+      {
+        integrity: sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==,
+      }
     dependencies:
       "@babel/parser": 7.12.11
       "@babel/types": 7.12.12
@@ -1506,478 +2005,636 @@ packages:
       "@types/babel__template": 7.4.0
       "@types/babel__traverse": 7.11.0
     dev: true
-    resolution:
-      integrity: sha512-wMTHiiTiBAAPebqaPiPDLFA4LYPKr6Ph0Xq/6rq1Ur3v66HXyG+clfR9CNETkD7MQS8ZHvpQOtA53DLws5WAEQ==
+
   /@types/babel__generator/7.6.2:
+    resolution:
+      {
+        integrity: sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==,
+      }
     dependencies:
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==
+
   /@types/babel__template/7.4.0:
+    resolution:
+      {
+        integrity: sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==,
+      }
     dependencies:
       "@babel/parser": 7.12.11
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==
+
   /@types/babel__traverse/7.11.0:
+    resolution:
+      {
+        integrity: sha512-kSjgDMZONiIfSH1Nxcr5JIRMwUetDki63FSQfpTCz8ogF3Ulqm8+mr5f78dUYs6vMiB6gBusQqfQmBvHZj/lwg==,
+      }
     dependencies:
       "@babel/types": 7.12.12
     dev: true
-    resolution:
-      integrity: sha512-kSjgDMZONiIfSH1Nxcr5JIRMwUetDki63FSQfpTCz8ogF3Ulqm8+mr5f78dUYs6vMiB6gBusQqfQmBvHZj/lwg==
+
   /@types/estree/0.0.39:
-    dev: true
     resolution:
-      integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==
+      {
+        integrity: sha512-EYNwp3bU+98cpU4lAWYYL7Zz+2gryWH1qbdDTidVd6hkiR6weksdbMadyXKXNPEkQFhXM+hVO9ZygomHXp+AIw==,
+      }
+    dev: true
+
   /@types/estree/0.0.46:
-    dev: true
     resolution:
-      integrity: sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==
+      {
+        integrity: sha512-laIjwTQaD+5DukBZaygQ79K1Z0jb1bPEMRrkXSLjtCcZm+abyp5YbrqpSLzD42FwWW6gK/aS4NYpJ804nG2brg==,
+      }
+    dev: true
+
   /@types/graceful-fs/4.1.4:
+    resolution:
+      {
+        integrity: sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==,
+      }
     dependencies:
       "@types/node": 14.14.22
     dev: true
-    resolution:
-      integrity: sha512-mWA/4zFQhfvOA8zWkXobwJvBD7vzcxgrOQ0J5CH1votGqdq9m7+FwtGaqyCZqC3NyyBkc9z4m+iry4LlqcMWJg==
+
   /@types/istanbul-lib-coverage/2.0.3:
-    dev: true
     resolution:
-      integrity: sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==
+      {
+        integrity: sha512-sz7iLqvVUg1gIedBOvlkxPlc8/uVzyS5OwGz1cKjXzkl3FpL3al0crU8YGU1WoHkxn0Wxbw5tyi6hvzJKNzFsw==,
+      }
+    dev: true
+
   /@types/istanbul-lib-report/3.0.0:
+    resolution:
+      {
+        integrity: sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==,
+      }
     dependencies:
       "@types/istanbul-lib-coverage": 2.0.3
     dev: true
-    resolution:
-      integrity: sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==
+
   /@types/istanbul-reports/3.0.0:
+    resolution:
+      {
+        integrity: sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==,
+      }
     dependencies:
       "@types/istanbul-lib-report": 3.0.0
     dev: true
-    resolution:
-      integrity: sha512-nwKNbvnwJ2/mndE9ItP/zc2TCzw6uuodnF4EHYWD+gCQDVBuRQL5UzbZD0/ezy1iKsFU2ZQiDqg4M9dN4+wZgA==
+
   /@types/jest/26.0.20:
+    resolution:
+      {
+        integrity: sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==,
+      }
     dependencies:
       jest-diff: 26.6.2
       pretty-format: 26.6.2
     dev: true
-    resolution:
-      integrity: sha512-9zi2Y+5USJRxd0FsahERhBwlcvFh6D2GLQnY2FH2BzK8J9s9omvNHIbvABwIluXa0fD8XVKMLTO0aOEuUfACAA==
+
   /@types/jsdom/16.2.6:
+    resolution:
+      {
+        integrity: sha512-yQA+HxknGtW9AkRTNyiSH3OKW5V+WzO8OPTdne99XwJkYC+KYxfNIcoJjeiSqP3V00PUUpFP6Myoo9wdIu78DQ==,
+      }
     dependencies:
       "@types/node": 14.14.22
       "@types/parse5": 5.0.3
       "@types/tough-cookie": 4.0.0
     dev: true
-    resolution:
-      integrity: sha512-yQA+HxknGtW9AkRTNyiSH3OKW5V+WzO8OPTdne99XwJkYC+KYxfNIcoJjeiSqP3V00PUUpFP6Myoo9wdIu78DQ==
+
   /@types/minimatch/3.0.3:
-    dev: true
     resolution:
-      integrity: sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==
+      {
+        integrity: sha512-tHq6qdbT9U1IRSGf14CL0pUlULksvY9OZ+5eEgl1N7t+OA3tGvNpxJCzuKQlsNgCVwbAs670L1vcVQi8j9HjnA==,
+      }
+    dev: true
+
   /@types/minimist/1.2.1:
-    dev: true
     resolution:
-      integrity: sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==
+      {
+        integrity: sha512-fZQQafSREFyuZcdWFAExYjBiCL7AUCdgsk80iO0q4yihYYdcIiH28CcuPTGFgLOCC8RlW49GSQxdHwZP+I7CNg==,
+      }
+    dev: true
+
   /@types/node/14.14.22:
-    dev: true
     resolution:
-      integrity: sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==
+      {
+        integrity: sha512-g+f/qj/cNcqKkc3tFqlXOYjrmZA+jNBiDzbP3kH+B+otKFqAdPgVTGP1IeKRdMml/aE69as5S4FqtxAbl+LaMw==,
+      }
+    dev: true
+
   /@types/normalize-package-data/2.4.0:
-    dev: true
     resolution:
-      integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==
+      {
+        integrity: sha512-f5j5b/Gf71L+dbqxIpQ4Z2WlmI/mPJ0fOkGGmFgtb6sAu97EPczzbS3/tJKxmcYDj55OX6ssqwDAWOHIYDRDGA==,
+      }
+    dev: true
+
   /@types/parse-json/4.0.0:
-    dev: true
     resolution:
-      integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==
+      {
+        integrity: sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==,
+      }
+    dev: true
+
   /@types/parse5/5.0.3:
     resolution:
-      integrity: sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==
+      {
+        integrity: sha512-kUNnecmtkunAoQ3CnjmMkzNU/gtxG8guhi+Fk2U/kOpIKjIMKnXGp4IJCgQJrXSgMsWYimYG4TGjz/UzbGEBTw==,
+      }
+
   /@types/prettier/2.1.6:
-    dev: true
     resolution:
-      integrity: sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==
+      {
+        integrity: sha512-6gOkRe7OIioWAXfnO/2lFiv+SJichKVSys1mSsgyrYHSEjk8Ctv4tSR/Odvnu+HWlH2C8j53dahU03XmQdd5fA==,
+      }
+    dev: true
+
   /@types/resolve/1.17.1:
+    resolution:
+      {
+        integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==,
+      }
     dependencies:
       "@types/node": 14.14.22
     dev: true
-    resolution:
-      integrity: sha512-yy7HuzQhj0dhGpD8RLXSZWEkLsV9ibvxvi6EiJ3bkqLAO1RGo0WbkWQiwpRlSFymTJRz0d3k5LM3kkx8ArDbLw==
+
   /@types/sinonjs__fake-timers/6.0.2:
-    dev: true
     resolution:
-      integrity: sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==
+      {
+        integrity: sha512-dIPoZ3g5gcx9zZEszaxLSVTvMReD3xxyyDnQUjA6IYDG9Ba2AV0otMPs+77sG9ojB4Qr2N2Vk5RnKeuA0X/0bg==,
+      }
+    dev: true
+
   /@types/sizzle/2.3.2:
-    dev: true
     resolution:
-      integrity: sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==
+      {
+        integrity: sha512-7EJYyKTL7tFR8+gDbB6Wwz/arpGa0Mywk1TJbNzKzHtzbwVmY4HR9WqS5VV7dsBUKQmPNr192jHr/VpBluj/hg==,
+      }
+    dev: true
+
   /@types/stack-utils/2.0.0:
-    dev: true
     resolution:
-      integrity: sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==
+      {
+        integrity: sha512-RJJrrySY7A8havqpGObOB4W92QXKJo63/jFLLgpvOtsGUqbQZ9Sbgl35KMm1DjC6j7AvmmU2bIno+3IyEaemaw==,
+      }
+    dev: true
+
   /@types/systemjs/6.1.0:
-    dev: true
     resolution:
-      integrity: sha512-akhlviqwowzRNiz3ooAbkjvyMO8cikBqap9z/0yfvMAb6vIsp91Rfox67qtgIhZosWP01MVSTwsgSFYWo4SWQA==
+      {
+        integrity: sha512-akhlviqwowzRNiz3ooAbkjvyMO8cikBqap9z/0yfvMAb6vIsp91Rfox67qtgIhZosWP01MVSTwsgSFYWo4SWQA==,
+      }
+    dev: true
+
   /@types/testing-library__jest-dom/5.9.5:
+    resolution:
+      {
+        integrity: sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==,
+      }
     dependencies:
       "@types/jest": 26.0.20
     dev: true
-    resolution:
-      integrity: sha512-ggn3ws+yRbOHog9GxnXiEZ/35Mow6YtPZpd7Z5mKDeZS/o7zx3yAle0ov/wjhVB5QT4N2Dt+GNoGCdqkBGCajQ==
+
   /@types/tough-cookie/4.0.0:
-    dev: true
     resolution:
-      integrity: sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==
+      {
+        integrity: sha512-I99sngh224D0M7XgW1s120zxCt3VYQ3IQsuw3P3jbq5GG4yc79+ZjyKznyOGIQrflfylLgcfekeZW/vk0yng6A==,
+      }
+    dev: true
+
   /@types/yargs-parser/20.2.0:
-    dev: true
     resolution:
-      integrity: sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==
+      {
+        integrity: sha512-37RSHht+gzzgYeobbG+KWryeAW8J33Nhr69cjTqSYymXVZEN9NbRYWoYlRtDhHKPVT1FyNKwaTPC1NynKZpzRA==,
+      }
+    dev: true
+
   /@types/yargs/15.0.12:
+    resolution:
+      {
+        integrity: sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==,
+      }
     dependencies:
       "@types/yargs-parser": 20.2.0
     dev: true
-    resolution:
-      integrity: sha512-f+fD/fQAo3BCbCDlrUpznF1A5Zp9rB0noS5vnoormHSIPFKL0Z2DcUJ3Gxp5ytH4uLRNxy7AwYUC9exZzqGMAw==
+
   /abab/2.0.5:
-    dev: true
     resolution:
-      integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==
+      {
+        integrity: sha512-9IK9EadsbHo6jLWIpxpR6pL0sazTXV6+SQv25ZB+F7Bj9mJNaOc4nCRabwd5M/JwmUa8idz6Eci6eKfJryPs6Q==,
+      }
+    dev: true
+
   /abbrev/1.1.1:
-    dev: true
     resolution:
-      integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==
+      {
+        integrity: sha512-nne9/IiQ/hzIhY6pdDnbBtz7DjPTKrY00P/zvPSm5pOFkl6xuGrGnXn/VtTNNfNtAfZ9/1RtehkszU9qcTii0Q==,
+      }
+    dev: true
+
   /acorn-globals/6.0.0:
+    resolution:
+      {
+        integrity: sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==,
+      }
     dependencies:
       acorn: 7.4.1
       acorn-walk: 7.2.0
     dev: true
-    resolution:
-      integrity: sha512-ZQl7LOWaF5ePqqcX4hLuv/bLXYQNfNWw2c0/yX/TsPRKamzHcTGQnlCjHT3TsmkOUVEPS3crCxiPfdzE/Trlhg==
+
   /acorn-jsx/5.3.1_acorn@7.4.1:
+    resolution:
+      {
+        integrity: sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==,
+      }
+    peerDependencies:
+      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
     dependencies:
       acorn: 7.4.1
     dev: true
-    peerDependencies:
-      acorn: ^6.0.0 || ^7.0.0 || ^8.0.0
-    resolution:
-      integrity: sha512-K0Ptm/47OKfQRpNQ2J/oIN/3QYiK6FwW+eJbILhsdxh2WTLdl+30o8aGdTbm5JbffpFFAg/g+zi1E+jvJha5ng==
+
   /acorn-walk/7.2.0:
-    dev: true
-    engines:
-      node: ">=0.4.0"
     resolution:
-      integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
+      {
+        integrity: sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==,
+      }
+    engines: { node: ">=0.4.0" }
+    dev: true
+
   /acorn/7.4.1:
-    dev: true
-    engines:
-      node: ">=0.4.0"
-    hasBin: true
     resolution:
-      integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
+      {
+        integrity: sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==,
+      }
+    engines: { node: ">=0.4.0" }
+    hasBin: true
+    dev: true
+
   /agent-base/6.0.2:
+    resolution:
+      {
+        integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==,
+      }
+    engines: { node: ">= 6.0.0" }
     dependencies:
       debug: 4.3.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">= 6.0.0"
-    resolution:
-      integrity: sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
+
   /agentkeepalive/4.1.3:
+    resolution:
+      {
+        integrity: sha512-wn8fw19xKZwdGPO47jivonaHRTd+nGOMP1z11sgGeQzDy2xd5FG0R67dIMcKHDE2cJ5y+YXV30XVGUBPRSY7Hg==,
+      }
+    engines: { node: ">= 8.0.0" }
     dependencies:
       debug: 4.3.1
       depd: 1.1.2
       humanize-ms: 1.2.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">= 8.0.0"
-    resolution:
-      integrity: sha512-wn8fw19xKZwdGPO47jivonaHRTd+nGOMP1z11sgGeQzDy2xd5FG0R67dIMcKHDE2cJ5y+YXV30XVGUBPRSY7Hg==
+
   /aggregate-error/3.1.0:
+    resolution:
+      {
+        integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       clean-stack: 2.2.0
       indent-string: 4.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-4I7Td01quW/RpocfNayFdFVk1qSuoh0E7JrbRJ16nH01HhKFQ88INq9Sd+nd72zqRySlr9BmDA8xlEJ6vJMrYA==
+
   /ajv/6.12.6:
+    resolution:
+      {
+        integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==,
+      }
     dependencies:
       fast-deep-equal: 3.1.3
       fast-json-stable-stringify: 2.1.0
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
     dev: true
-    resolution:
-      integrity: sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==
+
   /ajv/7.0.3:
+    resolution:
+      {
+        integrity: sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==,
+      }
     dependencies:
       fast-deep-equal: 3.1.3
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
       uri-js: 4.4.1
     dev: true
-    resolution:
-      integrity: sha512-R50QRlXSxqXcQP5SvKUrw8VZeypvo12i2IX0EeR5PiZ7bEKeHWgzgo264LDadUsCU42lTJVhFikTqJwNeH34gQ==
+
   /ansi-align/3.0.0:
+    resolution:
+      {
+        integrity: sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==,
+      }
     dependencies:
       string-width: 3.1.0
     dev: true
-    resolution:
-      integrity: sha512-ZpClVKqXN3RGBmKibdfWzqCY4lnjEuoNzU5T0oEFpfd/z5qJHVarukridD4juLO2FXMiwUQxr9WqQtaYa8XRYw==
+
   /ansi-colors/4.1.1:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==
+      {
+        integrity: sha512-JoX0apGbHaUJBNl6yF+p6JAFYZ666/hhCGKN5t9QFjbJQKUU/g8MNbFDbvfrgKXvI1QpZplPOnwIo99lX/AAmA==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /ansi-escapes/3.2.0:
-    dev: true
-    engines:
-      node: ">=4"
     resolution:
-      integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==
+      {
+        integrity: sha512-cBhpre4ma+U0T1oM5fXg7Dy1Jw7zzwv7lt/GoCpr+hDQJoYnKVPLL4dCvSEFMmQurOQvSrwT7SL/DAlhBI97RQ==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /ansi-escapes/4.3.1:
+    resolution:
+      {
+        integrity: sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       type-fest: 0.11.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-JWF7ocqNrp8u9oqpgV+wH5ftbt+cfvv+PTjOvKLT3AdYly/LmORARfEVT1iyjwN+4MqE5UmVKoAdIBqeoCHgLA==
+
   /ansi-regex/2.1.1:
+    resolution: { integrity: sha1-w7M6te42DYbg5ijwRorn7yfWVN8= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-w7M6te42DYbg5ijwRorn7yfWVN8=
+
   /ansi-regex/3.0.0:
+    resolution: { integrity: sha1-7QMXwyIGT3lGbAKWa922Bas32Zg= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-7QMXwyIGT3lGbAKWa922Bas32Zg=
+
   /ansi-regex/4.1.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==
+      {
+        integrity: sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /ansi-regex/5.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==
+      {
+        integrity: sha512-bY6fj56OUQ0hU1KjFNDQuJFezqKdrAyFdIevADiqrWHwSlbmBNMHp5ak2f40Pm8JTFyM2mqxkG6ngkHO11f/lg==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /ansi-styles/2.2.1:
+    resolution: { integrity: sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=
+
   /ansi-styles/3.2.1:
+    resolution:
+      {
+        integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==,
+      }
+    engines: { node: ">=4" }
     dependencies:
       color-convert: 1.9.3
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==
+
   /ansi-styles/4.3.0:
+    resolution:
+      {
+        integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       color-convert: 2.0.1
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==
+
   /any-observable/0.3.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==
+      {
+        integrity: sha512-/FQM1EDkTsf63Ub2C6O7GuYFDsSXUwsaZDurV0np41ocwq0jthUAYCmhBX9f+KwlaCgIuWyr/4WlUQUBfKfZog==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /anymatch/2.0.0:
+    resolution:
+      {
+        integrity: sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==,
+      }
     dependencies:
       micromatch: 3.1.10
       normalize-path: 2.1.1
     dev: true
-    resolution:
-      integrity: sha512-5teOsQWABXHHBFP9y3skS5P3d/WfWXpv3FUpy+LorMrNYaT9pI4oLMQX7jzQ2KklNpGpWHzdCXTDT2Y3XGlZBw==
+
   /anymatch/3.1.1:
+    resolution:
+      {
+        integrity: sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==,
+      }
+    engines: { node: ">= 8" }
     dependencies:
       normalize-path: 3.0.0
       picomatch: 2.2.2
     dev: true
-    engines:
-      node: ">= 8"
-    resolution:
-      integrity: sha512-mM8522psRCqzV+6LhomX5wgp25YVibjh8Wj23I5RPkPppSVSjyKD2A2mBJmWGa+KN7f2D6LNh9jkBCeyLktzjg==
+
   /aproba/1.2.0:
-    dev: true
     resolution:
-      integrity: sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==
+      {
+        integrity: sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==,
+      }
+    dev: true
+
   /arch/2.2.0:
-    dev: true
     resolution:
-      integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==
+      {
+        integrity: sha512-Of/R0wqp83cgHozfIYLbBMnej79U/SVGOOyuB3VVFv1NRM/PSFMK12x9KVtiYzJqmnU5WR2qp0Z5rHb7sWGnFQ==,
+      }
+    dev: true
+
   /are-we-there-yet/1.1.5:
+    resolution:
+      {
+        integrity: sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==,
+      }
     dependencies:
       delegates: 1.0.0
       readable-stream: 2.3.7
     dev: true
-    resolution:
-      integrity: sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==
+
   /argparse/1.0.10:
+    resolution:
+      {
+        integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==,
+      }
     dependencies:
       sprintf-js: 1.0.3
     dev: true
-    resolution:
-      integrity: sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
+
   /aria-query/4.2.2:
+    resolution:
+      {
+        integrity: sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==,
+      }
+    engines: { node: ">=6.0" }
     dependencies:
       "@babel/runtime": 7.12.5
       "@babel/runtime-corejs3": 7.12.5
     dev: true
-    engines:
-      node: ">=6.0"
-    resolution:
-      integrity: sha512-o/HelwhuKpTj/frsOsbNLNgnNGVIFsVP/SW2BSF14gVl7kAfMOJ6/8wUAUvG1R1NHKrfG+2sHZTu0yauT1qBrA==
+
   /arr-diff/4.0.0:
+    resolution: { integrity: sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-1kYQdP6/7HHn4VI1dhoyml3HxSA=
+
   /arr-flatten/1.1.0:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==
+      {
+        integrity: sha512-L3hKV5R/p5o81R7O02IGnwpDmkp6E982XhtbuwSe3O4qOtMMMtodicASA1Cny2U+aCXcNpml+m4dPsvsJ3jatg==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /arr-union/3.1.0:
+    resolution: { integrity: sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=
+
   /array-differ/3.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==
+      {
+        integrity: sha512-THtfYS6KtME/yIAhKjZ2ul7XI96lQGHRputJQHO80LAWQnuGP4iCIN8vdMRboGbIEYBwU33q8Tch1os2+X0kMg==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /array-union/2.1.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
+      {
+        integrity: sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /array-unique/0.3.2:
+    resolution: { integrity: sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-qJS3XUvE9s1nnvMkSp/Y9Gri1Cg=
+
   /array.prototype.flatmap/1.2.4:
+    resolution:
+      {
+        integrity: sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==,
+      }
+    engines: { node: ">= 0.4" }
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
       es-abstract: 1.18.0-next.2
       function-bind: 1.1.1
     dev: true
-    engines:
-      node: ">= 0.4"
-    resolution:
-      integrity: sha512-r9Z0zYoxqHz60vvQbWEdXIEtCwHF0yxaWfno9qzXeNHvfyl3BZqygmGzb84dsubyaXLH4husF+NFgMSdpZhk2Q==
+
   /arrify/1.0.1:
+    resolution: { integrity: sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-iYUI2iIm84DfkEcoRWhJwVAaSw0=
+
   /arrify/2.0.1:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==
+      {
+        integrity: sha512-3duEwti880xqi4eAMN8AyR4a0ByT90zoYdLlevfrvU43vb0YZwZVfxOgxWrLXXXpyugL0hNZc9G6BiB5B3nUug==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /asap/2.0.6:
+    resolution: { integrity: sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY= }
     dev: true
-    resolution:
-      integrity: sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
+
   /asn1/0.2.4:
+    resolution:
+      {
+        integrity: sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==,
+      }
     dependencies:
       safer-buffer: 2.1.2
     dev: true
-    resolution:
-      integrity: sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==
+
   /assert-plus/1.0.0:
+    resolution: { integrity: sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU= }
+    engines: { node: ">=0.8" }
     dev: true
-    engines:
-      node: ">=0.8"
-    resolution:
-      integrity: sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=
+
   /assign-symbols/1.0.0:
+    resolution: { integrity: sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-WWZ/QfrdTyDMvCu5a41Pf3jsA2c=
+
   /astral-regex/2.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==
+      {
+        integrity: sha512-Z7tMw1ytTXt5jqMcOP+OQteU1VuNK9Y02uuJtKQ1Sv69jXQKKg5cibLwGJow8yzZP+eAc18EmLGPal0bp36rvQ==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /async/3.2.0:
-    dev: true
     resolution:
-      integrity: sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==
+      {
+        integrity: sha512-TR2mEZFVOj2pLStYxLht7TyfuRzaydfpxr3k9RpHIzMgw7A64dzsdqCxH1WJyQdoe8T10nDXd9wnEigmiuHIZw==,
+      }
+    dev: true
+
   /asynckit/0.4.0:
+    resolution: { integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k= }
     dev: true
-    resolution:
-      integrity: sha1-x57Zf380y48robyXkLzDZkdLS3k=
+
   /at-least-node/1.0.0:
-    dev: true
-    engines:
-      node: ">= 4.0.0"
     resolution:
-      integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==
+      {
+        integrity: sha512-+q/t7Ekv1EDY2l6Gda6LLiX14rU9TV20Wa3ofeQmwPFZbOMo9DXrLbOjFaaclkXKWidIaopwAObQDqwWtGUjqg==,
+      }
+    engines: { node: ">= 4.0.0" }
+    dev: true
+
   /atob/2.1.2:
-    dev: true
-    engines:
-      node: ">= 4.5.0"
+    resolution:
+      {
+        integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==,
+      }
+    engines: { node: ">= 4.5.0" }
     hasBin: true
-    resolution:
-      integrity: sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==
+    dev: true
+
   /aws-sign2/0.7.0:
+    resolution: { integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg= }
     dev: true
-    resolution:
-      integrity: sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=
+
   /aws4/1.11.0:
-    dev: true
     resolution:
-      integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==
-  /babel-eslint/11.0.0-beta.2_b5d2baead2359fee426c65690feab125:
-    dependencies:
-      "@babel/core": 7.12.10
-      eslint: 7.18.0
-      eslint-scope: 5.0.0
-      eslint-visitor-keys: 1.3.0
-      semver: 6.3.0
+      {
+        integrity: sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA==,
+      }
     dev: true
-    engines:
-      node: ">=8"
-    peerDependencies:
-      "@babel/core": ">=7.2.0"
-      eslint: ">= 6.0.0"
-    resolution:
-      integrity: sha512-D2tunrOu04XloEdU2XVUminUu25FILlGruZmffqH5OSnLDhCheKNvUoM1ihrexdUvhizlix8bjqRnsss4V/UIQ==
+
   /babel-jest/26.6.3_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==,
+      }
+    engines: { node: ">= 10.14.2" }
+    peerDependencies:
+      "@babel/core": ^7.0.0
     dependencies:
       "@babel/core": 7.12.10
       "@jest/transform": 26.6.2
@@ -1988,43 +2645,55 @@ packages:
       chalk: 4.1.0
       graceful-fs: 4.2.4
       slash: 3.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    peerDependencies:
-      "@babel/core": ^7.0.0
-    resolution:
-      integrity: sha512-pl4Q+GAVOHwvjrck6jKjvmGhnO3jHX/xuB9d27f+EJZ/6k+6nMuPjorrYp7s++bKKdANwzElBWnLWaObvTnaZA==
+
   /babel-plugin-dynamic-import-node/2.3.3:
+    resolution:
+      {
+        integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==,
+      }
     dependencies:
       object.assign: 4.1.2
     dev: true
-    resolution:
-      integrity: sha512-jZVI+s9Zg3IqA/kdi0i6UDCybUI3aSBLnglhYbSSjKlV7yF1F/5LWv8MakQmvYpnbJDS6fcBL2KzHSxNCMtWSQ==
+
   /babel-plugin-istanbul/6.0.0:
+    resolution:
+      {
+        integrity: sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       "@babel/helper-plugin-utils": 7.10.4
       "@istanbuljs/load-nyc-config": 1.1.0
       "@istanbuljs/schema": 0.1.2
       istanbul-lib-instrument: 4.0.3
       test-exclude: 6.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-AF55rZXpe7trmEylbaE1Gv54wn6rwU03aptvRoVIGP8YykoSxqdVLV1TfwflBCE/QtHmqtP8SWlTENqbK8GCSQ==
+
   /babel-plugin-jest-hoist/26.6.2:
+    resolution:
+      {
+        integrity: sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@babel/template": 7.12.7
       "@babel/types": 7.12.12
       "@types/babel__core": 7.1.12
       "@types/babel__traverse": 7.11.0
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-PO9t0697lNTmcEHH69mdtYiOIkkOlj9fySqfO3K1eCcdISevLAE0xY59VLLUj0SoiPiTX/JU2CYFpILydUa5Lw==
+
   /babel-preset-current-node-syntax/1.0.1_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==,
+      }
+    peerDependencies:
+      "@babel/core": ^7.0.0
     dependencies:
       "@babel/core": 7.12.10
       "@babel/plugin-syntax-async-generators": 7.8.4_@babel+core@7.12.10
@@ -2040,27 +2709,31 @@ packages:
       "@babel/plugin-syntax-optional-chaining": 7.8.3_@babel+core@7.12.10
       "@babel/plugin-syntax-top-level-await": 7.12.1_@babel+core@7.12.10
     dev: true
+
+  /babel-preset-jest/26.6.2_@babel+core@7.12.10:
+    resolution:
+      {
+        integrity: sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==,
+      }
+    engines: { node: ">= 10.14.2" }
     peerDependencies:
       "@babel/core": ^7.0.0
-    resolution:
-      integrity: sha512-M7LQ0bxarkxQoN+vz5aJPsLBn77n8QgTFmo8WK0/44auK2xlCXrYcUxHFxgU7qW5Yzw/CjmLRK2uJzaCd7LvqQ==
-  /babel-preset-jest/26.6.2_@babel+core@7.12.10:
     dependencies:
       "@babel/core": 7.12.10
       babel-plugin-jest-hoist: 26.6.2
       babel-preset-current-node-syntax: 1.0.1_@babel+core@7.12.10
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    peerDependencies:
-      "@babel/core": ^7.0.0
-    resolution:
-      integrity: sha512-YvdtlVm9t3k777c5NPQIv6cxFFFapys25HiUmuSgHwIZhfifweR5c5Sf5nwE3MAbfu327CYSvps8Yx6ANLyleQ==
+
   /balanced-match/1.0.0:
+    resolution: { integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c= }
     dev: true
-    resolution:
-      integrity: sha1-ibTRmasr7kneFk6gK4nORi1xt2c=
+
   /base/0.11.2:
+    resolution:
+      {
+        integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       cache-base: 1.0.1
       class-utils: 0.3.6
@@ -2070,25 +2743,33 @@ packages:
       mixin-deep: 1.3.2
       pascalcase: 0.1.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==
+
   /bcrypt-pbkdf/1.0.2:
+    resolution: { integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4= }
     dependencies:
       tweetnacl: 0.14.5
     dev: true
-    resolution:
-      integrity: sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=
+
   /blob-util/2.0.2:
-    dev: true
     resolution:
-      integrity: sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==
+      {
+        integrity: sha512-T7JQa+zsXXEa6/8ZhHcQEW1UFfVM49Ts65uBkFL6fz2QmrElqmbajIDJvuA0tEhRe5eIjpV9ZF+0RfZR9voJFQ==,
+      }
+    dev: true
+
   /bluebird/3.7.2:
-    dev: true
     resolution:
-      integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
+      {
+        integrity: sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==,
+      }
+    dev: true
+
   /boxen/4.2.0:
+    resolution:
+      {
+        integrity: sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       ansi-align: 3.0.0
       camelcase: 5.3.1
@@ -2099,18 +2780,23 @@ packages:
       type-fest: 0.8.1
       widest-line: 3.1.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-eB4uT9RGzg2odpER62bBwSLvUeGC+WbRjjyyFhGsKnc8wp/m0+hQsMUvUe3H2V0D5vw0nBdO1hCJoZo5mKeuIQ==
+
   /brace-expansion/1.1.11:
+    resolution:
+      {
+        integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==,
+      }
     dependencies:
       balanced-match: 1.0.0
       concat-map: 0.0.1
     dev: true
-    resolution:
-      integrity: sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==
+
   /braces/2.3.2:
+    resolution:
+      {
+        integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       arr-flatten: 1.1.0
       array-unique: 0.3.2
@@ -2123,23 +2809,31 @@ packages:
       split-string: 3.1.0
       to-regex: 3.0.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-aNdbnj9P8PjdXU4ybaWLK2IF3jc/EoDYbC7AazW6to3TRsfXxscC9UXOB5iDiEQrkyIbWp2SLQda4+QAa7nc3w==
+
   /braces/3.0.2:
+    resolution:
+      {
+        integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       fill-range: 7.0.1
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==
+
   /browser-process-hrtime/1.0.0:
-    dev: true
     resolution:
-      integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==
+      {
+        integrity: sha512-9o5UecI3GhkpM6DrXr69PblIuWxPKk9Y0jHBRhdocZ2y7YECBFCsHm79Pr3OyR2AvjhDkabFJaDJMYRazHgsow==,
+      }
+    dev: true
+
   /browserslist/4.16.1:
+    resolution:
+      {
+        integrity: sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==,
+      }
+    engines: { node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7 }
+    hasBin: true
     dependencies:
       caniuse-lite: 1.0.30001179
       colorette: 1.2.1
@@ -2147,36 +2841,45 @@ packages:
       escalade: 3.1.1
       node-releases: 1.1.70
     dev: true
-    engines:
-      node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7
-    hasBin: true
-    resolution:
-      integrity: sha512-UXhDrwqsNcpTYJBTZsbGATDxZbiVDsx6UjpmRUmtnP10pr8wAYr5LgFoEFw9ixriQH2mv/NX2SfGzE/o8GndLA==
+
   /bser/2.1.1:
+    resolution:
+      {
+        integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==,
+      }
     dependencies:
       node-int64: 0.4.0
     dev: true
-    resolution:
-      integrity: sha512-gQxTNE/GAfIIrmHLUE3oJyp5FO6HRBfhjnw4/wMmA63ZGDJnWBmgY/lyQBpnDUkGmAhbSe39tx2d/iTOAfglwQ==
+
   /buffer-crc32/0.2.13:
+    resolution: { integrity: sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI= }
     dev: true
-    resolution:
-      integrity: sha1-DTM+PwDqxQqhRUq9MO+MKl2ackI=
+
   /buffer-from/1.1.1:
-    dev: true
     resolution:
-      integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==
+      {
+        integrity: sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==,
+      }
+    dev: true
+
   /builtin-modules/3.2.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==
+      {
+        integrity: sha512-lGzLKcioL90C7wMczpkY0n/oART3MbBa8R9OFGE1rJxoVI86u4WAGfEk8Wjv10eKSyTHVGkSo3bvBylCEtk7LA==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /builtins/1.0.3:
+    resolution: { integrity: sha1-y5T662HIaWRR2zZTThQi+U8K7og= }
     dev: true
-    resolution:
-      integrity: sha1-y5T662HIaWRR2zZTThQi+U8K7og=
+
   /cacache/15.0.5:
+    resolution:
+      {
+        integrity: sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==,
+      }
+    engines: { node: ">= 10" }
     dependencies:
       "@npmcli/move-file": 1.1.0
       chownr: 2.0.0
@@ -2196,11 +2899,13 @@ packages:
       tar: 6.1.0
       unique-filename: 1.1.1
     dev: true
-    engines:
-      node: ">= 10"
-    resolution:
-      integrity: sha512-lloiL22n7sOjEEXdL8NAjTgv9a1u43xICE9/203qonkZUCj5X1UEWIdf2/Y0d6QcCtMzbKQyhrcDbdvlZTs/+A==
+
   /cache-base/1.0.1:
+    resolution:
+      {
+        integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       collection-visit: 1.0.0
       component-emitter: 1.3.0
@@ -2212,11 +2917,13 @@ packages:
       union-value: 1.0.1
       unset-value: 1.0.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==
+
   /cacheable-request/6.1.0:
+    resolution:
+      {
+        integrity: sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       clone-response: 1.0.2
       get-stream: 5.2.0
@@ -2226,68 +2933,85 @@ packages:
       normalize-url: 4.5.0
       responselike: 1.0.2
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-Oj3cAGPCqOZX7Rz64Uny2GYAZNliQSqfbePrgAQ1wKAihYmCUnraBtJtKcGR4xz7wF+LoJC+ssFZvv5BgF9Igg==
+
   /cachedir/2.3.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==
+      {
+        integrity: sha512-A+Fezp4zxnit6FanDmv9EqXNAi3vt9DWp51/71UEhXukb7QUuvtv9344h91dyAxuTLoSYJFU299qzR3tzwPAhw==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /call-bind/1.0.2:
+    resolution:
+      {
+        integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==,
+      }
     dependencies:
       function-bind: 1.1.1
       get-intrinsic: 1.0.2
     dev: true
-    resolution:
-      integrity: sha512-7O+FbCihrB5WGbFYesctwmTKae6rOiIzmz1icreWJ+0aA7LJfuqhEso2T9ncpcFtzMQtzXf2QGGueWJGTYsqrA==
+
   /callsites/3.1.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
+      {
+        integrity: sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /camelcase-keys/6.2.2:
+    resolution:
+      {
+        integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       camelcase: 5.3.1
       map-obj: 4.1.0
       quick-lru: 4.0.1
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
+
   /camelcase/5.3.1:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
+      {
+        integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /camelcase/6.2.0:
-    dev: true
-    engines:
-      node: ">=10"
     resolution:
-      integrity: sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
+      {
+        integrity: sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==,
+      }
+    engines: { node: ">=10" }
+    dev: true
+
   /caniuse-lite/1.0.30001179:
-    dev: true
     resolution:
-      integrity: sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==
+      {
+        integrity: sha512-blMmO0QQujuUWZKyVrD1msR4WNDAqb/UPO1Sw2WWsQ7deoM5bJiicKnWJ1Y0NS/aGINSnKPIWBMw5luX+NDUCA==,
+      }
+    dev: true
+
   /capture-exit/2.0.0:
+    resolution:
+      {
+        integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==,
+      }
+    engines: { node: 6.* || 8.* || >= 10.* }
     dependencies:
       rsvp: 4.8.5
     dev: true
-    engines:
-      node: 6.* || 8.* || >= 10.*
-    resolution:
-      integrity: sha512-PiT/hQmTonHhl/HFGN+Lx3JJUznrVYJ3+AQsnthneZbvW7x+f08Tk7yLJTLEOUvBTbduLeeBkxEaYXUOUrRq6g==
+
   /caseless/0.12.0:
+    resolution: { integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw= }
     dev: true
-    resolution:
-      integrity: sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=
+
   /chalk/1.1.3:
+    resolution: { integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       ansi-styles: 2.2.1
       escape-string-regexp: 1.0.5
@@ -2295,264 +3019,325 @@ packages:
       strip-ansi: 3.0.1
       supports-color: 2.0.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=
+
   /chalk/2.4.2:
+    resolution:
+      {
+        integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==,
+      }
+    engines: { node: ">=4" }
     dependencies:
       ansi-styles: 3.2.1
       escape-string-regexp: 1.0.5
       supports-color: 5.5.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==
+
   /chalk/3.0.0:
+    resolution:
+      {
+        integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==
+
   /chalk/4.1.0:
+    resolution:
+      {
+        integrity: sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       ansi-styles: 4.3.0
       supports-color: 7.2.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-qwx12AxXe2Q5xQ43Ac//I6v5aXTipYrSESdOgzrN+9XjgEpyjpKuvSGaN4qE93f7TQTlerQQ8S+EQ0EyDoVL1A==
+
   /char-regex/1.0.2:
-    dev: true
-    engines:
-      node: ">=10"
     resolution:
-      integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==
+      {
+        integrity: sha512-kWWXztvZ5SBQV+eRgKFeh8q5sLuZY2+8WUIzlxWVTg+oGwY14qylx1KbKzHd8P6ZYkAg0xyIDU9JMHhyJMZ1jw==,
+      }
+    engines: { node: ">=10" }
+    dev: true
+
   /check-more-types/2.24.0:
+    resolution: { integrity: sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA= }
+    engines: { node: ">= 0.8.0" }
     dev: true
-    engines:
-      node: ">= 0.8.0"
-    resolution:
-      integrity: sha1-FCD/sQ/URNz8ebQ4kbv//TKoRgA=
+
   /chownr/2.0.0:
-    dev: true
-    engines:
-      node: ">=10"
     resolution:
-      integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==
+      {
+        integrity: sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ==,
+      }
+    engines: { node: ">=10" }
+    dev: true
+
   /ci-info/2.0.0:
-    dev: true
     resolution:
-      integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==
+      {
+        integrity: sha512-5tK7EtrZ0N+OLFMthtqOj4fI2Jeb88C4CAZPu25LDVUgXJ0A3Js4PMGqrn0JU1W0Mh1/Z8wZzYPxqUrXeBboCQ==,
+      }
+    dev: true
+
   /cjs-module-lexer/0.6.0:
-    dev: true
     resolution:
-      integrity: sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==
+      {
+        integrity: sha512-uc2Vix1frTfnuzxxu1Hp4ktSvM3QaI4oXl4ZUqL1wjTu/BGki9TrCWoqLTg/drR1KwAEarXuRFCG2Svr1GxPFw==,
+      }
+    dev: true
+
   /class-utils/0.3.6:
+    resolution:
+      {
+        integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       arr-union: 3.1.0
       define-property: 0.2.5
       isobject: 3.0.1
       static-extend: 0.1.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==
+
   /clean-stack/2.2.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==
+      {
+        integrity: sha512-4diC9HaTE+KRAMWhDhrGOECgWZxoevMc5TlkObMqNSsVU62PYzXZ/SMTjzyGAFF1YusgxGcSWTEXBhp0CPwQ1A==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /cli-boxes/2.2.1:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==
+      {
+        integrity: sha512-y4coMcylgSCdVinjiDBuR8PCC2bLjyGTwEmPb9NHR/QaNU6EUOXcTY/s6VjGMD6ENSEaeQYHCY0GNGS5jfMwPw==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /cli-cursor/1.0.2:
+    resolution: { integrity: sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       restore-cursor: 1.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-ZNo/fValRBLll5S9Ytw1KV6PKYc=
+
   /cli-cursor/2.1.0:
+    resolution: { integrity: sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU= }
+    engines: { node: ">=4" }
     dependencies:
       restore-cursor: 2.0.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=
+
   /cli-table3/0.6.0:
+    resolution:
+      {
+        integrity: sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==,
+      }
+    engines: { node: 10.* || >= 12.* }
     dependencies:
       object-assign: 4.1.1
       string-width: 4.2.0
-    dev: true
-    engines:
-      node: 10.* || >= 12.*
     optionalDependencies:
       colors: 1.4.0
-    resolution:
-      integrity: sha512-gnB85c3MGC7Nm9I/FkiasNBOKjOiO1RNuXXarQms37q4QMpWdlbBgD/VnOStA2faG1dpXMv31RFApjX1/QdgWQ==
+    dev: true
+
   /cli-truncate/0.2.1:
+    resolution: { integrity: sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       slice-ansi: 0.0.4
       string-width: 1.0.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-nxXPuwcFAFNpIWxiasfQWrkN1XQ=
+
   /cliui/5.0.0:
+    resolution:
+      {
+        integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==,
+      }
     dependencies:
       string-width: 3.1.0
       strip-ansi: 5.2.0
       wrap-ansi: 5.1.0
     dev: true
-    resolution:
-      integrity: sha512-PYeGSEmmHM6zvoef2w8TPzlrnNpXIjTipYK780YswmIP9vjxmd6Y2a3CB2Ks6/AU8NHjZugXvo8w3oWM2qnwXA==
+
   /cliui/6.0.0:
+    resolution:
+      {
+        integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==,
+      }
     dependencies:
       string-width: 4.2.0
       strip-ansi: 6.0.0
       wrap-ansi: 6.2.0
     dev: true
-    resolution:
-      integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==
+
   /cliui/7.0.4:
+    resolution:
+      {
+        integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==,
+      }
     dependencies:
       string-width: 4.2.0
       strip-ansi: 6.0.0
       wrap-ansi: 7.0.0
     dev: true
-    resolution:
-      integrity: sha512-OcRE68cOsVMXp1Yvonl/fzkQOyjLSu/8bhPDfQt0e0/Eb283TKP20Fs2MqoPsr9SwA595rRCA+QMzYc9nBP+JQ==
+
   /clone-response/1.0.2:
+    resolution: { integrity: sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws= }
     dependencies:
       mimic-response: 1.0.1
     dev: true
-    resolution:
-      integrity: sha1-0dyXOSAxTfZ/vrlCI7TuNQI56Ws=
+
   /co/4.6.0:
+    resolution: { integrity: sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ= }
+    engines: { iojs: ">= 1.0.0", node: ">= 0.12.0" }
     dev: true
-    engines:
-      iojs: ">= 1.0.0"
-      node: ">= 0.12.0"
-    resolution:
-      integrity: sha1-bqa989hTrlTMuOR7+gvz+QMfsYQ=
+
   /code-point-at/1.1.0:
+    resolution: { integrity: sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=
+
   /collect-v8-coverage/1.0.1:
-    dev: true
     resolution:
-      integrity: sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==
+      {
+        integrity: sha512-iBPtljfCNcTKNAto0KEtDfZ3qzjJvqE3aTGZsbhjSBlorqpXJlaWWtPO35D+ZImoC3KWejX64o+yPGxhWSTzfg==,
+      }
+    dev: true
+
   /collection-visit/1.0.0:
+    resolution: { integrity: sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       map-visit: 1.0.0
       object-visit: 1.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=
+
   /color-convert/1.9.3:
+    resolution:
+      {
+        integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==,
+      }
     dependencies:
       color-name: 1.1.3
     dev: true
-    resolution:
-      integrity: sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==
+
   /color-convert/2.0.1:
+    resolution:
+      {
+        integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==,
+      }
+    engines: { node: ">=7.0.0" }
     dependencies:
       color-name: 1.1.4
     dev: true
-    engines:
-      node: ">=7.0.0"
-    resolution:
-      integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==
+
   /color-name/1.1.3:
+    resolution: { integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU= }
     dev: true
-    resolution:
-      integrity: sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=
+
   /color-name/1.1.4:
-    dev: true
     resolution:
-      integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==
+      {
+        integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==,
+      }
+    dev: true
+
   /colorette/1.2.1:
-    dev: true
     resolution:
-      integrity: sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==
+      {
+        integrity: sha512-puCDz0CzydiSYOrnXpz/PKd69zRrribezjtE9yd4zvytoRc8+RY/KJPvtPFKZS3E3wP6neGyMe0vOTlHO5L3Pw==,
+      }
+    dev: true
+
   /colors/1.4.0:
-    dev: true
-    engines:
-      node: ">=0.1.90"
-    optional: true
     resolution:
-      integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==
+      {
+        integrity: sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA==,
+      }
+    engines: { node: ">=0.1.90" }
+    dev: true
+    optional: true
+
   /combined-stream/1.0.8:
+    resolution:
+      {
+        integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==,
+      }
+    engines: { node: ">= 0.8" }
     dependencies:
       delayed-stream: 1.0.0
     dev: true
-    engines:
-      node: ">= 0.8"
-    resolution:
-      integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==
+
   /commander/2.20.3:
-    dev: true
     resolution:
-      integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+      {
+        integrity: sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==,
+      }
+    dev: true
+
   /commander/5.1.0:
-    dev: true
-    engines:
-      node: ">= 6"
     resolution:
-      integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==
+      {
+        integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==,
+      }
+    engines: { node: ">= 6" }
+    dev: true
+
   /common-tags/1.8.0:
-    dev: true
-    engines:
-      node: ">=4.0.0"
     resolution:
-      integrity: sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==
+      {
+        integrity: sha512-6P6g0uetGpW/sdyUy/iQQCbFF0kWVMSIVSyYz7Zgjcgh8mgw8PQzDNZeyZ5DQ2gM7LBoZPHmnjz8rUthkBG5tw==,
+      }
+    engines: { node: ">=4.0.0" }
+    dev: true
+
   /commondir/1.0.1:
+    resolution: { integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs= }
     dev: true
-    resolution:
-      integrity: sha1-3dgA2gxmEnOTzKWVDqloo6rxJTs=
+
   /compare-versions/3.6.0:
-    dev: true
     resolution:
-      integrity: sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==
+      {
+        integrity: sha512-W6Af2Iw1z4CB7q4uU4hv646dW9GQuBM+YpC0UvUCWSD8w90SJjp+ujJuXaEMtAXBtSqGfMPuFOVn4/+FlaqfBA==,
+      }
+    dev: true
+
   /component-emitter/1.3.0:
-    dev: true
     resolution:
-      integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==
+      {
+        integrity: sha512-Rd3se6QB+sO1TwqZjscQrurpEPIfO0/yYnSin6Q/rD3mOutHvUrCAhJub3r90uNb+SESBuE0QYoB90YdfatsRg==,
+      }
+    dev: true
+
   /concat-map/0.0.1:
+    resolution: { integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s= }
     dev: true
-    resolution:
-      integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=
+
   /concat-stream/1.6.2:
+    resolution:
+      {
+        integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==,
+      }
+    engines: { "0": node >= 0.8 }
     dependencies:
       buffer-from: 1.1.1
       inherits: 2.0.4
       readable-stream: 2.3.7
       typedarray: 0.0.6
     dev: true
-    engines:
-      "0": node >= 0.8
-    resolution:
-      integrity: sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==
+
   /concurrently/5.3.0:
+    resolution:
+      {
+        integrity: sha512-8MhqOB6PWlBfA2vJ8a0bSFKATOdWlHiQlk11IfmQBPaHVP8oP2gsh2MObE6UR3hqDHqvaIvLTyceNW6obVuFHQ==,
+      }
+    engines: { node: ">=6.0.0" }
+    hasBin: true
     dependencies:
       chalk: 2.4.2
       date-fns: 2.16.1
@@ -2564,12 +3349,13 @@ packages:
       tree-kill: 1.2.2
       yargs: 13.3.2
     dev: true
-    engines:
-      node: ">=6.0.0"
-    hasBin: true
-    resolution:
-      integrity: sha512-8MhqOB6PWlBfA2vJ8a0bSFKATOdWlHiQlk11IfmQBPaHVP8oP2gsh2MObE6UR3hqDHqvaIvLTyceNW6obVuFHQ==
+
   /configstore/5.0.1:
+    resolution:
+      {
+        integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       dot-prop: 5.3.0
       graceful-fs: 4.2.4
@@ -2578,43 +3364,53 @@ packages:
       write-file-atomic: 3.0.3
       xdg-basedir: 4.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-aMKprgk5YhBNyH25hj8wGt2+D52Sw1DRRIzqBwLp2Ya9mFmY8KPvvtvmna8SxVR9JMZ4kzMD68N22vlaRpkeFA==
+
   /console-control-strings/1.1.0:
+    resolution: { integrity: sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4= }
     dev: true
-    resolution:
-      integrity: sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=
+
   /convert-source-map/1.7.0:
+    resolution:
+      {
+        integrity: sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==,
+      }
     dependencies:
       safe-buffer: 5.1.2
     dev: true
-    resolution:
-      integrity: sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==
+
   /copy-descriptor/0.1.1:
+    resolution: { integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
+
   /core-js-compat/3.8.3:
+    resolution:
+      {
+        integrity: sha512-1sCb0wBXnBIL16pfFG1Gkvei6UzvKyTNYpiC41yrdjEv0UoJoq9E/abTMzyYJ6JpTkAj15dLjbqifIzEBDVvog==,
+      }
     dependencies:
       browserslist: 4.16.1
       semver: 7.0.0
     dev: true
-    resolution:
-      integrity: sha512-1sCb0wBXnBIL16pfFG1Gkvei6UzvKyTNYpiC41yrdjEv0UoJoq9E/abTMzyYJ6JpTkAj15dLjbqifIzEBDVvog==
+
   /core-js-pure/3.8.3:
-    dev: true
+    resolution:
+      {
+        integrity: sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA==,
+      }
     requiresBuild: true
-    resolution:
-      integrity: sha512-V5qQZVAr9K0xu7jXg1M7qTEwuxUgqr7dUOezGaNa7i+Xn9oXAU/d1fzqD9ObuwpVQOaorO5s70ckyi1woP9lVA==
-  /core-util-is/1.0.2:
     dev: true
-    resolution:
-      integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=
+
+  /core-util-is/1.0.2:
+    resolution: { integrity: sha1-tf1UIgqivFq1eqtxQMlAdUUDwac= }
+    dev: true
+
   /cosmiconfig/7.0.0:
+    resolution:
+      {
+        integrity: sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       "@types/parse-json": 4.0.0
       import-fresh: 3.3.0
@@ -2622,22 +3418,24 @@ packages:
       path-type: 4.0.0
       yaml: 1.10.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-pondGvTuVYDk++upghXJabWzL6Kxu6f26ljFw64Swq9v6sQPUL3EUlVDV56diOjpCayKihL6hVe8exIACU4XcA==
+
   /cross-env/7.0.3:
+    resolution:
+      {
+        integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==,
+      }
+    engines: { node: ">=10.14", npm: ">=6", yarn: ">=1" }
+    hasBin: true
     dependencies:
       cross-spawn: 7.0.3
     dev: true
-    engines:
-      node: ">=10.14"
-      npm: ">=6"
-      yarn: ">=1"
-    hasBin: true
-    resolution:
-      integrity: sha512-+/HKd6EgcQCJGh2PSjZuUitQBQynKor4wrFbRg4DtAgS1aWO+gU52xpH7M9ScGgXSYmAVS9bIJ8EzuaGw0oNAw==
+
   /cross-spawn/6.0.5:
+    resolution:
+      {
+        integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==,
+      }
+    engines: { node: ">=4.8" }
     dependencies:
       nice-try: 1.0.5
       path-key: 2.0.1
@@ -2645,55 +3443,74 @@ packages:
       shebang-command: 1.2.0
       which: 1.3.1
     dev: true
-    engines:
-      node: ">=4.8"
-    resolution:
-      integrity: sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==
+
   /cross-spawn/7.0.3:
+    resolution:
+      {
+        integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==,
+      }
+    engines: { node: ">= 8" }
     dependencies:
       path-key: 3.1.1
       shebang-command: 2.0.0
       which: 2.0.2
     dev: true
-    engines:
-      node: ">= 8"
-    resolution:
-      integrity: sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==
+
   /crypto-random-string/2.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+      {
+        integrity: sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /css.escape/1.5.1:
+    resolution: { integrity: sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s= }
     dev: true
-    resolution:
-      integrity: sha1-QuJ9T6BK4y+TGktNQZH6nN3ul8s=
+
   /css/3.0.0:
+    resolution:
+      {
+        integrity: sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==,
+      }
     dependencies:
       inherits: 2.0.4
       source-map: 0.6.1
       source-map-resolve: 0.6.0
     dev: true
-    resolution:
-      integrity: sha512-DG9pFfwOrzc+hawpmqX/dHYHJG+Bsdb0klhyi1sDneOgGOXy9wQIC8hzyVp1e4NRYDBdxcylvywPkkXCHAzTyQ==
+
   /cssom/0.3.8:
-    dev: true
     resolution:
-      integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==
+      {
+        integrity: sha512-b0tGHbfegbhPJpxpiBPU2sCkigAqtM9O121le6bbOlgyV+NyGyCmVfJ6QW9eRjz8CpNfWEOYBIMIGRYkLwsIYg==,
+      }
+    dev: true
+
   /cssom/0.4.4:
-    dev: true
     resolution:
-      integrity: sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==
+      {
+        integrity: sha512-p3pvU7r1MyyqbTk+WbNJIgJjG2VmTIaB10rI93LzVPrmDJKkzKYMtxxyAvQXR/NS6otuzveI7+7BBq3SjBS2mw==,
+      }
+    dev: true
+
   /cssstyle/2.3.0:
+    resolution:
+      {
+        integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       cssom: 0.3.8
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-AZL67abkUzIuvcHqk7c09cezpGNcxUxU4Ioi/05xHk4DQeTkWmGYftIE6ctU6AEt+Gn4n1lDStOtj7FKycP71A==
+
   /cypress/5.6.0:
+    resolution:
+      {
+        integrity: sha512-cs5vG3E2JLldAc16+5yQxaVRLLqMVya5RlrfPWkC72S5xrlHFdw7ovxPb61s4wYweROKTyH01WQc2PFzwwVvyQ==,
+      }
+    engines: { node: ">=10.0.0" }
+    hasBin: true
+    requiresBuild: true
     dependencies:
       "@cypress/listr-verbose-renderer": 0.4.1
       "@cypress/request": 2.88.5
@@ -2733,356 +3550,442 @@ packages:
       untildify: 4.0.0
       url: 0.11.0
       yauzl: 2.10.0
+    transitivePeerDependencies:
+      - zen-observable
     dev: true
-    engines:
-      node: ">=10.0.0"
-    hasBin: true
-    requiresBuild: true
-    resolution:
-      integrity: sha512-cs5vG3E2JLldAc16+5yQxaVRLLqMVya5RlrfPWkC72S5xrlHFdw7ovxPb61s4wYweROKTyH01WQc2PFzwwVvyQ==
+
   /dashdash/1.14.1:
+    resolution: { integrity: sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA= }
+    engines: { node: ">=0.10" }
     dependencies:
       assert-plus: 1.0.0
     dev: true
-    engines:
-      node: ">=0.10"
-    resolution:
-      integrity: sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=
+
   /data-urls/2.0.0:
+    resolution:
+      {
+        integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       abab: 2.0.5
       whatwg-mimetype: 2.3.0
       whatwg-url: 8.4.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-X5eWTSXO/BJmpdIKCRuKUgSCgAN0OwliVK3yPKbwIWU1Tdw5BRajxlzMidvh+gwko9AfQ9zIj52pzF91Q3YAvQ==
+
   /date-fns/1.30.1:
-    dev: true
     resolution:
-      integrity: sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
+      {
+        integrity: sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==,
+      }
+    dev: true
+
   /date-fns/2.16.1:
-    dev: true
-    engines:
-      node: ">=0.11"
     resolution:
-      integrity: sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==
+      {
+        integrity: sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==,
+      }
+    engines: { node: ">=0.11" }
+    dev: true
+
   /debug/2.6.9:
+    resolution:
+      {
+        integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==,
+      }
     dependencies:
       ms: 2.0.0
     dev: true
-    resolution:
-      integrity: sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==
+
   /debug/3.2.7:
+    resolution:
+      {
+        integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==,
+      }
     dependencies:
       ms: 2.1.3
     dev: true
-    resolution:
-      integrity: sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==
+
   /debug/4.3.1:
-    dependencies:
-      ms: 2.1.2
-    dev: true
-    engines:
-      node: ">=6.0"
+    resolution:
+      {
+        integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==,
+      }
+    engines: { node: ">=6.0" }
     peerDependencies:
       supports-color: "*"
     peerDependenciesMeta:
       supports-color:
         optional: true
-    resolution:
-      integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+    dependencies:
+      ms: 2.1.2
+    dev: true
+
   /debug/4.3.1_supports-color@7.2.0:
+    resolution:
+      {
+        integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==,
+      }
+    engines: { node: ">=6.0" }
+    peerDependencies:
+      supports-color: "*"
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
     dependencies:
       ms: 2.1.2
       supports-color: 7.2.0
     dev: true
-    engines:
-      node: ">=6.0"
-    peerDependencies:
-      supports-color: "*"
-    peerDependenciesMeta:
-      supports-color:
-        optional: true
-    resolution:
-      integrity: sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==
+
   /debuglog/1.0.1:
+    resolution: { integrity: sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI= }
     dev: true
-    resolution:
-      integrity: sha1-qiT/uaw9+aI1GDfPstJ5NgzXhJI=
+
   /decamelize-keys/1.1.0:
+    resolution: { integrity: sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       decamelize: 1.2.0
       map-obj: 1.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-0XGoeTMlKAfrPLYdwcFEXQeN8tk=
+
   /decamelize/1.2.0:
+    resolution: { integrity: sha1-9lNNFRSCabIDUue+4m9QH5oZEpA= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-9lNNFRSCabIDUue+4m9QH5oZEpA=
+
   /decimal.js/10.2.1:
-    dev: true
     resolution:
-      integrity: sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==
+      {
+        integrity: sha512-KaL7+6Fw6i5A2XSnsbhm/6B+NuEA7TZ4vqxnd5tXz9sbKtrN9Srj8ab4vKVdK8YAqZO9P1kg45Y6YLoduPf+kw==,
+      }
+    dev: true
+
   /decode-uri-component/0.2.0:
+    resolution: { integrity: sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU= }
+    engines: { node: ">=0.10" }
     dev: true
-    engines:
-      node: ">=0.10"
-    resolution:
-      integrity: sha1-6zkTMzRYd1y4TNGh+uBiEGu4dUU=
+
   /decompress-response/3.3.0:
+    resolution: { integrity: sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M= }
+    engines: { node: ">=4" }
     dependencies:
       mimic-response: 1.0.1
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=
+
   /deep-extend/0.6.0:
-    dev: true
-    engines:
-      node: ">=4.0.0"
     resolution:
-      integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==
+      {
+        integrity: sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==,
+      }
+    engines: { node: ">=4.0.0" }
+    dev: true
+
   /deep-is/0.1.3:
+    resolution: { integrity: sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ= }
     dev: true
-    resolution:
-      integrity: sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=
+
   /deepmerge/4.2.2:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==
+      {
+        integrity: sha512-FJ3UgI4gIl+PHZm53knsuSFpE+nESMr7M4v9QcgB7S63Kj/6WqMiFQJpBBYz1Pt+66bZpP3Q7Lye0Oo9MPKEdg==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /defer-to-connect/1.1.3:
-    dev: true
     resolution:
-      integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==
+      {
+        integrity: sha512-0ISdNousHvZT2EiFlZeZAHBUvSxmKswVCEf8hW7KWgG4a8MVEu/3Vb6uWYozkjylyCxe0JBIiRB1jV45S70WVQ==,
+      }
+    dev: true
+
   /define-properties/1.1.3:
+    resolution:
+      {
+        integrity: sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==,
+      }
+    engines: { node: ">= 0.4" }
     dependencies:
       object-keys: 1.1.1
     dev: true
-    engines:
-      node: ">= 0.4"
-    resolution:
-      integrity: sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==
+
   /define-property/0.2.5:
+    resolution: { integrity: sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-descriptor: 0.1.6
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=
+
   /define-property/1.0.0:
+    resolution: { integrity: sha1-dp66rz9KY6rTr56NMEybvnm/sOY= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-descriptor: 1.0.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-dp66rz9KY6rTr56NMEybvnm/sOY=
+
   /define-property/2.0.2:
+    resolution:
+      {
+        integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-descriptor: 1.0.2
       isobject: 3.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-jwK2UV4cnPpbcG7+VRARKTZPUWowwXA8bzH5NP6ud0oeAxyYPuGZUAC7hMugpCdz4BeSZl2Dl9k66CHJ/46ZYQ==
+
   /delayed-stream/1.0.0:
+    resolution: { integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk= }
+    engines: { node: ">=0.4.0" }
     dev: true
-    engines:
-      node: ">=0.4.0"
-    resolution:
-      integrity: sha1-3zrhmayt+31ECqrgsp4icrJOxhk=
+
   /delegates/1.0.0:
+    resolution: { integrity: sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o= }
     dev: true
-    resolution:
-      integrity: sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=
+
   /depd/1.1.2:
+    resolution: { integrity: sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak= }
+    engines: { node: ">= 0.6" }
     dev: true
-    engines:
-      node: ">= 0.6"
-    resolution:
-      integrity: sha1-m81S4UwJd2PnSbJ0xDRu0uVgtak=
+
   /detect-newline/3.1.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+      {
+        integrity: sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /dezalgo/1.0.3:
+    resolution: { integrity: sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY= }
     dependencies:
       asap: 2.0.6
       wrappy: 1.0.2
     dev: true
-    resolution:
-      integrity: sha1-f3Qt4Gb8dIvI24IFad3c5Jvw1FY=
+
   /diff-sequences/26.6.2:
-    dev: true
-    engines:
-      node: ">= 10.14.2"
     resolution:
-      integrity: sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==
+      {
+        integrity: sha512-Mv/TDa3nZ9sbc5soK+OoA74BsS3mL37yixCvUAQkiuA4Wz6YtwP/K47n2rv2ovzHZvoiQeA5FTQOschKkEwB0Q==,
+      }
+    engines: { node: ">= 10.14.2" }
+    dev: true
+
   /diffable-html/4.0.0:
+    resolution:
+      {
+        integrity: sha512-keJdgy2qBkdrrnwP1YE6e834d4Y+mV0aRFzk8w7WzyAJVbQVfcJltSmUWB3r/NOoO/0jt7RdJlvy5ioyqvmQcw==,
+      }
     dependencies:
       htmlparser2: 3.10.1
     dev: true
-    resolution:
-      integrity: sha512-keJdgy2qBkdrrnwP1YE6e834d4Y+mV0aRFzk8w7WzyAJVbQVfcJltSmUWB3r/NOoO/0jt7RdJlvy5ioyqvmQcw==
+
   /dir-glob/3.0.1:
+    resolution:
+      {
+        integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       path-type: 4.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==
+
   /doctrine/3.0.0:
+    resolution:
+      {
+        integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==,
+      }
+    engines: { node: ">=6.0.0" }
     dependencies:
       esutils: 2.0.3
     dev: true
-    engines:
-      node: ">=6.0.0"
-    resolution:
-      integrity: sha512-yS+Q5i3hBf7GBkd4KG8a7eBNNWNGLTaEwwYWUijIYM7zrlYDM0BFXHjjPWlWZ1Rg7UaddZeIDmi9jF3HmqiQ2w==
+
   /dom-accessibility-api/0.5.4:
-    dev: true
     resolution:
-      integrity: sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==
+      {
+        integrity: sha512-TvrjBckDy2c6v6RLxPv5QXOnU+SmF9nBII5621Ve5fu6Z/BDrENurBEvlC1f44lKEUVqOpK4w9E5Idc5/EgkLQ==,
+      }
+    dev: true
+
   /dom-serializer/0.2.2:
+    resolution:
+      {
+        integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==,
+      }
     dependencies:
       domelementtype: 2.1.0
       entities: 2.1.0
     dev: true
-    resolution:
-      integrity: sha512-2/xPb3ORsQ42nHYiSunXkDjPLBaEj/xTwUO4B7XCZQTRk7EBtTOPaygh10YAAh2OI1Qrp6NWfpAhzswj0ydt9g==
+
   /domelementtype/1.3.1:
-    dev: true
     resolution:
-      integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==
+      {
+        integrity: sha512-BSKB+TSpMpFI/HOxCNr1O8aMOTZ8hT3pM3GQ0w/mWRmkhEDSFJkkyzz4XQsBV44BChwGkrDfMyjVD0eA2aFV3w==,
+      }
+    dev: true
+
   /domelementtype/2.1.0:
-    dev: true
     resolution:
-      integrity: sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==
+      {
+        integrity: sha512-LsTgx/L5VpD+Q8lmsXSHW2WpA+eBlZ9HPf3erD1IoPF00/3JKHZ3BknUVA2QGDNu69ZNmyFmCWBSO45XjYKC5w==,
+      }
+    dev: true
+
   /domexception/2.0.1:
+    resolution:
+      {
+        integrity: sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       webidl-conversions: 5.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-yxJ2mFy/sibVQlu5qHjOkf9J3K6zgmCxgJ94u2EdvDOV09H+32LtRswEcUsmUWN72pVLOEnTSRaIVVzVQgS0dg==
+
   /domhandler/2.4.2:
+    resolution:
+      {
+        integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==,
+      }
     dependencies:
       domelementtype: 1.3.1
     dev: true
-    resolution:
-      integrity: sha512-JiK04h0Ht5u/80fdLMCEmV4zkNh2BcoMFBmZ/91WtYZ8qVXSKjiw7fXMgFPnHcSZgOo3XdinHvmnDUeMf5R4wA==
+
   /domutils/1.7.0:
+    resolution:
+      {
+        integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==,
+      }
     dependencies:
       dom-serializer: 0.2.2
       domelementtype: 1.3.1
     dev: true
-    resolution:
-      integrity: sha512-Lgd2XcJ/NjEw+7tFvfKxOzCYKZsdct5lczQ2ZaQY8Djz7pfAD3Gbp8ySJWtreII/vDlMVmxwa6pHmdxIYgttDg==
+
   /dot-prop/5.3.0:
+    resolution:
+      {
+        integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       is-obj: 2.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-QM8q3zDe58hqUqjraQOmzZ1LIH9SWQJTlEKCH4kJ2oQvLZk7RbQXvtDM2XEq3fwkV9CCvvH4LA0AV+ogFsBM2Q==
+
   /duplexer3/0.1.4:
+    resolution: { integrity: sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI= }
     dev: true
-    resolution:
-      integrity: sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI=
+
   /ecc-jsbn/0.1.2:
+    resolution: { integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk= }
     dependencies:
       jsbn: 0.1.1
       safer-buffer: 2.1.2
     dev: true
-    resolution:
-      integrity: sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=
+
   /electron-to-chromium/1.3.643:
-    dev: true
     resolution:
-      integrity: sha512-TGomM4gj8adt/uqRgPbu9F0yhUVAR1deww5X0fvbQgpGr9suSMjLgc4IwQ9YKGkp1t03cDbZum20OfAkiTYjAg==
+      {
+        integrity: sha512-TGomM4gj8adt/uqRgPbu9F0yhUVAR1deww5X0fvbQgpGr9suSMjLgc4IwQ9YKGkp1t03cDbZum20OfAkiTYjAg==,
+      }
+    dev: true
+
   /elegant-spinner/1.0.1:
+    resolution: { integrity: sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-2wQ1IcldfjA/2PNFvtwzSc+wcp4=
+
   /emittery/0.7.2:
-    dev: true
-    engines:
-      node: ">=10"
     resolution:
-      integrity: sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==
+      {
+        integrity: sha512-A8OG5SR/ij3SsJdWDJdkkSYUjQdCUx6APQXem0SaEePBSRg4eymGYwBkKo1Y6DU+af/Jn2dBQqDBvjnr9Vi8nQ==,
+      }
+    engines: { node: ">=10" }
+    dev: true
+
   /emoji-regex/7.0.3:
-    dev: true
     resolution:
-      integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==
+      {
+        integrity: sha512-CwBLREIQ7LvYFB0WyRvwhq5N5qPhc6PMjD6bYggFlI5YyDgl+0vxq5VHbMOFqLg7hfWzmu8T5Z1QofhmTIhItA==,
+      }
+    dev: true
+
   /emoji-regex/8.0.0:
-    dev: true
     resolution:
-      integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==
+      {
+        integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==,
+      }
+    dev: true
+
   /encoding/0.1.13:
+    resolution:
+      {
+        integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==,
+      }
     dependencies:
       iconv-lite: 0.6.2
     dev: true
     optional: true
-    resolution:
-      integrity: sha512-ETBauow1T35Y/WZMkio9jiM0Z5xjHHmJ4XmjZOq1l/dXz3lr2sRn87nJy20RupqSh1F2m3HHPSp8ShIPQJrJ3A==
+
   /end-of-stream/1.4.4:
+    resolution:
+      {
+        integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==,
+      }
     dependencies:
       once: 1.4.0
     dev: true
-    resolution:
-      integrity: sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==
+
   /enquirer/2.3.6:
+    resolution:
+      {
+        integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==,
+      }
+    engines: { node: ">=8.6" }
     dependencies:
       ansi-colors: 4.1.1
     dev: true
-    engines:
-      node: ">=8.6"
-    resolution:
-      integrity: sha512-yjNnPr315/FjS4zIsUxYguYUPP2e1NK4d7E7ZOLiyYCcbFBiTMyID+2wvm2w6+pZ/odMA7cRkjhsPbltwBOrLg==
+
   /entities/1.1.2:
-    dev: true
     resolution:
-      integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==
+      {
+        integrity: sha512-f2LZMYl1Fzu7YSBKg+RoROelpOaNrcGmE9AZubeDfrCEia483oW4MI4VyFd5VNHIgQ/7qm1I0wUHK1eJnn2y2w==,
+      }
+    dev: true
+
   /entities/2.1.0:
-    dev: true
     resolution:
-      integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==
+      {
+        integrity: sha512-hCx1oky9PFrJ611mf0ifBLBRW8lUUVRlFolb5gWRfIELabBlbp9xZvrqZLZAs+NxFnbfQoeGd8wDkygjg7U85w==,
+      }
+    dev: true
+
   /env-paths/2.2.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==
+      {
+        integrity: sha512-6u0VYSCo/OW6IoD5WCLLy9JUGARbamfSavcNXry/eu8aHVFei6CD3Sw+VGX5alea1i9pgPHW0mbu6Xj0uBh7gA==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /err-code/1.1.2:
+    resolution: { integrity: sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA= }
     dev: true
-    resolution:
-      integrity: sha1-BuARbTAo9q70gGhJ6w6mp0iuaWA=
+
   /error-ex/1.3.2:
+    resolution:
+      {
+        integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==,
+      }
     dependencies:
       is-arrayish: 0.2.1
     dev: true
-    resolution:
-      integrity: sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==
+
   /es-abstract/1.18.0-next.2:
+    resolution:
+      {
+        integrity: sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==,
+      }
+    engines: { node: ">= 0.4" }
     dependencies:
       call-bind: 1.0.2
       es-to-primitive: 1.2.1
@@ -3099,72 +4002,89 @@ packages:
       string.prototype.trimend: 1.0.3
       string.prototype.trimstart: 1.0.3
     dev: true
-    engines:
-      node: ">= 0.4"
-    resolution:
-      integrity: sha512-Ih4ZMFHEtZupnUh6497zEL4y2+w8+1ljnCyaTa+adcoafI1GOvMwFlDjBLfWR7y9VLfrjRJe9ocuHY1PSR9jjw==
+
   /es-to-primitive/1.2.1:
+    resolution:
+      {
+        integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==,
+      }
+    engines: { node: ">= 0.4" }
     dependencies:
       is-callable: 1.2.2
       is-date-object: 1.0.2
       is-symbol: 1.0.3
     dev: true
-    engines:
-      node: ">= 0.4"
-    resolution:
-      integrity: sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
+
   /escalade/3.1.1:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
+      {
+        integrity: sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /escape-goat/2.1.1:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==
+      {
+        integrity: sha512-8/uIhbG12Csjy2JEW7D9pHbreaVaS/OpN3ycnyvElTdwM5n6GY6W6e2IPemfvGZeUMqZ9A/3GqIZMgKnBhAw/Q==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /escape-string-regexp/1.0.5:
+    resolution: { integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ= }
+    engines: { node: ">=0.8.0" }
     dev: true
-    engines:
-      node: ">=0.8.0"
-    resolution:
-      integrity: sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=
+
   /escape-string-regexp/2.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==
+      {
+        integrity: sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /escodegen/1.14.3:
+    resolution:
+      {
+        integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==,
+      }
+    engines: { node: ">=4.0" }
+    hasBin: true
     dependencies:
       esprima: 4.0.1
       estraverse: 4.3.0
       esutils: 2.0.3
       optionator: 0.8.3
-    dev: true
-    engines:
-      node: ">=4.0"
-    hasBin: true
     optionalDependencies:
       source-map: 0.6.1
-    resolution:
-      integrity: sha512-qFcX0XJkdg+PB3xjZZG/wKSuT1PnQWx57+TVSjIMmILd2yC/6ByYElPwJnslDsuWuSAp4AwJGumarAAmJch5Kw==
-  /eslint-config-important-stuff/1.1.0:
     dev: true
+
+  /eslint-config-important-stuff/1.1.0:
     resolution:
-      integrity: sha512-CsV6QFsjNDTZTDEgE1XxhTKph4YJUh5XFMdsWv3p+9DuMyvfy40fsnZiwqXZHBVEUNMHf+zfPGk6s6b4fS9Erw==
+      {
+        integrity: sha512-CsV6QFsjNDTZTDEgE1XxhTKph4YJUh5XFMdsWv3p+9DuMyvfy40fsnZiwqXZHBVEUNMHf+zfPGk6s6b4fS9Erw==,
+      }
+    dev: true
+
   /eslint-config-node-important-stuff/1.1.0_eslint@7.18.0:
+    resolution:
+      {
+        integrity: sha512-bG6bnD0P81rWYIU2yY3RUxnjz7BoDushsTsDUfg0tZlujXHqApaR2tN1AskHk/FEOYOB7hObY9NxmPdiT8jctA==,
+      }
     dependencies:
       eslint-config-important-stuff: 1.1.0
       eslint-plugin-node: 11.1.0_eslint@7.18.0
+    transitivePeerDependencies:
+      - eslint
     dev: true
-    peerDependencies:
-      eslint: "*"
-    resolution:
-      integrity: sha512-bG6bnD0P81rWYIU2yY3RUxnjz7BoDushsTsDUfg0tZlujXHqApaR2tN1AskHk/FEOYOB7hObY9NxmPdiT8jctA==
+
   /eslint-formatter-pretty/4.0.0:
+    resolution:
+      {
+        integrity: sha512-QgdeZxQwWcN0TcXXNZJiS6BizhAANFhCzkE7Yl9HKB7WjElzwED6+FbbZB2gji8ofgJTGPqKm6VRCNT3OGCeEw==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       ansi-escapes: 4.3.1
       chalk: 4.1.0
@@ -3174,31 +4094,40 @@ packages:
       string-width: 4.2.0
       supports-hyperlinks: 2.1.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-QgdeZxQwWcN0TcXXNZJiS6BizhAANFhCzkE7Yl9HKB7WjElzwED6+FbbZB2gji8ofgJTGPqKm6VRCNT3OGCeEw==
+
   /eslint-plugin-es/3.0.1_eslint@7.18.0:
+    resolution:
+      {
+        integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==,
+      }
+    engines: { node: ">=8.10.0" }
+    peerDependencies:
+      eslint: ">=4.19.1"
     dependencies:
       eslint: 7.18.0
       eslint-utils: 2.1.0
       regexpp: 3.1.0
     dev: true
-    engines:
-      node: ">=8.10.0"
-    peerDependencies:
-      eslint: ">=4.19.1"
-    resolution:
-      integrity: sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==
+
   /eslint-plugin-es5/1.5.0_eslint@7.18.0:
+    resolution:
+      {
+        integrity: sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==,
+      }
+    peerDependencies:
+      eslint: ">= 3.0.0"
     dependencies:
       eslint: 7.18.0
     dev: true
-    peerDependencies:
-      eslint: ">= 3.0.0"
-    resolution:
-      integrity: sha512-Qxmfo7v2B7SGAEURJo0dpBweFf+JU15kSyALfiB2rXWcBuJ96r6X9kFHXFnhdopPHCaHjoQs1xQPUJVbGMb1AA==
+
   /eslint-plugin-node/11.1.0_eslint@7.18.0:
+    resolution:
+      {
+        integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==,
+      }
+    engines: { node: ">=8.10.0" }
+    peerDependencies:
+      eslint: ">=5.16.0"
     dependencies:
       eslint: 7.18.0
       eslint-plugin-es: 3.0.1_eslint@7.18.0
@@ -3208,55 +4137,58 @@ packages:
       resolve: 1.19.0
       semver: 6.3.0
     dev: true
-    engines:
-      node: ">=8.10.0"
-    peerDependencies:
-      eslint: ">=5.16.0"
-    resolution:
-      integrity: sha512-oUwtPJ1W0SKD0Tr+wqu92c5xuCeQqB3hSCHasn/ZgjFdA9iDGNkNf2Zi9ztY7X+hNuMib23LNGRm6+uN+KLE3g==
+
   /eslint-rule-docs/1.1.219:
-    dev: true
     resolution:
-      integrity: sha512-MeihPfW6NSZkm9ia0OpqoZm0r8gU6xJoa+G1PqUCGGZMcJQpFeNTy1ItuNIrtZFsR6n0mVqYR4j55Rd3HxIb+Q==
-  /eslint-scope/5.0.0:
-    dependencies:
-      esrecurse: 4.3.0
-      estraverse: 4.3.0
+      {
+        integrity: sha512-MeihPfW6NSZkm9ia0OpqoZm0r8gU6xJoa+G1PqUCGGZMcJQpFeNTy1ItuNIrtZFsR6n0mVqYR4j55Rd3HxIb+Q==,
+      }
     dev: true
-    engines:
-      node: ">=8.0.0"
-    resolution:
-      integrity: sha512-oYrhJW7S0bxAFDvWqzvMPRm6pcgcnWc4QnofCAqRTRfQC0JcwenzGglTtsLyIuuWFfkqDG9vz67cnttSd53djw==
+
   /eslint-scope/5.1.1:
+    resolution:
+      {
+        integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==,
+      }
+    engines: { node: ">=8.0.0" }
     dependencies:
       esrecurse: 4.3.0
       estraverse: 4.3.0
     dev: true
-    engines:
-      node: ">=8.0.0"
-    resolution:
-      integrity: sha512-2NxwbF/hZ0KpepYN0cNbo+FN6XoK7GaHlQhgx/hIZl6Va0bF45RQOOwhLIy8lQDbuCiadSLCBnH2CFYquit5bw==
+
   /eslint-utils/2.1.0:
+    resolution:
+      {
+        integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       eslint-visitor-keys: 1.3.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==
+
   /eslint-visitor-keys/1.3.0:
-    dev: true
-    engines:
-      node: ">=4"
     resolution:
-      integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==
+      {
+        integrity: sha512-6J72N8UNa462wa/KFODt/PJ3IU60SDpC3QXC1Hjc1BXXpfL2C9R5+AU7jhe0F6GREqVMh4Juu+NY7xn+6dipUQ==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /eslint-visitor-keys/2.0.0:
-    dev: true
-    engines:
-      node: ">=10"
     resolution:
-      integrity: sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==
+      {
+        integrity: sha512-QudtT6av5WXels9WjIM7qz1XD1cWGvX4gGXvp/zBn9nXG02D0utdU3Em2m/QjTnrsk6bBjmCygl3rmj118msQQ==,
+      }
+    engines: { node: ">=10" }
+    dev: true
+
   /eslint/7.18.0:
+    resolution:
+      {
+        integrity: sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==,
+      }
+    engines: { node: ^10.12.0 || >=12.0.0 }
+    hasBin: true
     dependencies:
       "@babel/code-frame": 7.12.11
       "@eslint/eslintrc": 0.3.0
@@ -3295,80 +4227,109 @@ packages:
       table: 6.0.7
       text-table: 0.2.0
       v8-compile-cache: 2.2.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    hasBin: true
-    resolution:
-      integrity: sha512-fbgTiE8BfUJZuBeq2Yi7J3RB3WGUQ9PNuNbmgi6jt9Iv8qrkxfy19Ds3OpL1Pm7zg3BtTVhvcUZbIRQ0wmSjAQ==
+
   /espree/7.3.1:
+    resolution:
+      {
+        integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==,
+      }
+    engines: { node: ^10.12.0 || >=12.0.0 }
     dependencies:
       acorn: 7.4.1
       acorn-jsx: 5.3.1_acorn@7.4.1
       eslint-visitor-keys: 1.3.0
     dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    resolution:
-      integrity: sha512-v3JCNCE64umkFpmkFGqzVKsOT0tN1Zr+ueqLZfpV1Ob8e+CEgPWa+OxCoGH3tnhimMKIaBm4m/vaRpJ/krRz2g==
+
   /esprima/4.0.1:
-    dev: true
-    engines:
-      node: ">=4"
+    resolution:
+      {
+        integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==,
+      }
+    engines: { node: ">=4" }
     hasBin: true
-    resolution:
-      integrity: sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==
+    dev: true
+
   /esquery/1.3.1:
+    resolution:
+      {
+        integrity: sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==,
+      }
+    engines: { node: ">=0.10" }
     dependencies:
       estraverse: 5.2.0
     dev: true
-    engines:
-      node: ">=0.10"
-    resolution:
-      integrity: sha512-olpvt9QG0vniUBZspVRN6lwB7hOZoTRtT+jzR+tS4ffYx2mzbw+z0XCOk44aaLYKApNX5nMm+E+P6o25ip/DHQ==
+
   /esrecurse/4.3.0:
+    resolution:
+      {
+        integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==,
+      }
+    engines: { node: ">=4.0" }
     dependencies:
       estraverse: 5.2.0
     dev: true
-    engines:
-      node: ">=4.0"
-    resolution:
-      integrity: sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag==
+
   /estraverse/4.3.0:
-    dev: true
-    engines:
-      node: ">=4.0"
     resolution:
-      integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==
+      {
+        integrity: sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==,
+      }
+    engines: { node: ">=4.0" }
+    dev: true
+
   /estraverse/5.2.0:
-    dev: true
-    engines:
-      node: ">=4.0"
     resolution:
-      integrity: sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==
+      {
+        integrity: sha512-BxbNGGNm0RyRYvUdHpIwv9IWzeM9XClbOxwoATuFdOE7ZE6wHL+HQ5T8hoPM+zHvmKzzsEqhgy0GrQ5X13afiQ==,
+      }
+    engines: { node: ">=4.0" }
+    dev: true
+
   /estree-walker/1.0.1:
-    dev: true
     resolution:
-      integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==
+      {
+        integrity: sha512-1fMXF3YP4pZZVozF8j/ZLfvnR8NSIljt56UhbZ5PeeDmmGHpgpdwQt7ITlGvYaQukCvuBRMLEiKiYC+oeIg4cg==,
+      }
+    dev: true
+
   /estree-walker/2.0.2:
-    dev: true
     resolution:
-      integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==
+      {
+        integrity: sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==,
+      }
+    dev: true
+
   /esutils/2.0.3:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==
+      {
+        integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /eventemitter2/6.4.3:
-    dev: true
     resolution:
-      integrity: sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ==
+      {
+        integrity: sha512-t0A2msp6BzOf+QAcI6z9XMktLj52OjGQg+8SJH6v5+3uxNpWYRR3wQmfA+6xtMU9kOC59qk9licus5dYcrYkMQ==,
+      }
+    dev: true
+
   /exec-sh/0.3.4:
-    dev: true
     resolution:
-      integrity: sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==
+      {
+        integrity: sha512-sEFIkc61v75sWeOe72qyrqg2Qg0OuLESziUDk/O/z2qgS15y2gWVFrI6f2Qn/qw/0/NCfCEsmNA4zOjkwEZT1A==,
+      }
+    dev: true
+
   /execa/1.0.0:
+    resolution:
+      {
+        integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       cross-spawn: 6.0.5
       get-stream: 4.1.0
@@ -3378,11 +4339,13 @@ packages:
       signal-exit: 3.0.3
       strip-eof: 1.0.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-adbxcyWV46qiHyvSp50TKt05tB4tK3HcmF7/nxfAdhnox83seTDbwnaqKO4sXRy7roHAIFqJP/Rw/AuEbX61LA==
+
   /execa/4.1.0:
+    resolution:
+      {
+        integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       cross-spawn: 7.0.3
       get-stream: 5.2.0
@@ -3394,31 +4357,30 @@ packages:
       signal-exit: 3.0.3
       strip-final-newline: 2.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
+
   /executable/4.1.1:
+    resolution:
+      {
+        integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==,
+      }
+    engines: { node: ">=4" }
     dependencies:
       pify: 2.3.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha512-8iA79xD3uAch729dUG8xaaBBFGaEa0wdD2VkYLFHwlqosEj/jT66AzcreRDSgV7ehnNLBW2WR5jIXwGKjVdTLg==
+
   /exit-hook/1.1.1:
+    resolution: { integrity: sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-8FyiM7SMBdVP/wd2XfhQfpXAL/g=
+
   /exit/0.1.2:
+    resolution: { integrity: sha1-BjJjj42HfMghB9MKD/8aF8uhzQw= }
+    engines: { node: ">= 0.8.0" }
     dev: true
-    engines:
-      node: ">= 0.8.0"
-    resolution:
-      integrity: sha1-BjJjj42HfMghB9MKD/8aF8uhzQw=
+
   /expand-brackets/2.1.4:
+    resolution: { integrity: sha1-t3c14xXOMPa27/D4OwQVGiJEliI= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       debug: 2.6.9
       define-property: 0.2.5
@@ -3428,11 +4390,13 @@ packages:
       snapdragon: 0.8.2
       to-regex: 3.0.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-t3c14xXOMPa27/D4OwQVGiJEliI=
+
   /expect/26.6.2:
+    resolution:
+      {
+        integrity: sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/types": 26.6.2
       ansi-styles: 4.3.0
@@ -3441,32 +4405,35 @@ packages:
       jest-message-util: 26.6.2
       jest-regex-util: 26.0.0
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-9/hlOBkQl2l/PLHJx6JjoDF6xPKcJEsUlWKb23rKE7KzeDqUZKXKNMW27KIue5JMdBV9HgmoJPcc8HtO85t9IA==
+
   /extend-shallow/2.0.1:
+    resolution: { integrity: sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-extendable: 0.1.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=
+
   /extend-shallow/3.0.2:
+    resolution: { integrity: sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       assign-symbols: 1.0.0
       is-extendable: 1.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=
+
   /extend/3.0.2:
-    dev: true
     resolution:
-      integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==
+      {
+        integrity: sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==,
+      }
+    dev: true
+
   /extglob/2.0.4:
+    resolution:
+      {
+        integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       array-unique: 0.3.2
       define-property: 1.0.0
@@ -3477,31 +4444,38 @@ packages:
       snapdragon: 0.8.2
       to-regex: 3.0.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==
+
   /extract-zip/1.7.0:
+    resolution:
+      {
+        integrity: sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==,
+      }
+    hasBin: true
     dependencies:
       concat-stream: 1.6.2
       debug: 2.6.9
       mkdirp: 0.5.5
       yauzl: 2.10.0
     dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-xoh5G1W/PB0/27lXgMQyIhP5DSY/LhoCsOyZgb+6iMmRtCwVBo55uKaMoEYrDCKQhWvqEip5ZPKAc6eFNyf/MA==
+
   /extsprintf/1.3.0:
+    resolution: { integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU= }
+    engines: { "0": node >=0.6.0 }
     dev: true
-    engines:
-      "0": node >=0.6.0
-    resolution:
-      integrity: sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=
+
   /fast-deep-equal/3.1.3:
-    dev: true
     resolution:
-      integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==
+      {
+        integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==,
+      }
+    dev: true
+
   /fast-glob/3.2.5:
+    resolution:
+      {
+        integrity: sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       "@nodelib/fs.stat": 2.0.4
       "@nodelib/fs.walk": 1.2.6
@@ -3510,206 +4484,236 @@ packages:
       micromatch: 4.0.2
       picomatch: 2.2.2
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-2DtFcgT68wiTTiwZ2hNdJfcHNke9XOfnwmBRWXhmeKM8rF0TGwmC/Qto3S7RoZKp5cilZbxzO5iTNTQsJ+EeDg==
+
   /fast-json-stable-stringify/2.1.0:
-    dev: true
     resolution:
-      integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==
+      {
+        integrity: sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==,
+      }
+    dev: true
+
   /fast-levenshtein/2.0.6:
+    resolution: { integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc= }
     dev: true
-    resolution:
-      integrity: sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=
+
   /fastq/1.10.0:
+    resolution:
+      {
+        integrity: sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==,
+      }
     dependencies:
       reusify: 1.0.4
     dev: true
-    resolution:
-      integrity: sha512-NL2Qc5L3iQEsyYzweq7qfgy5OtXCmGzGvhElGEd/SoFWEMOEczNh5s5ocaF01HDetxz+p8ecjNPA6cZxxIHmzA==
+
   /fb-watchman/2.0.1:
+    resolution:
+      {
+        integrity: sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==,
+      }
     dependencies:
       bser: 2.1.1
     dev: true
-    resolution:
-      integrity: sha512-DkPJKQeY6kKwmuMretBhr7G6Vodr7bFwDYTXIkfG1gjvNpaxBTQV3PbXg6bR1c1UP4jPOX0jHUbbHANL9vRjVg==
+
   /fd-slicer/1.1.0:
+    resolution: { integrity: sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4= }
     dependencies:
       pend: 1.2.0
     dev: true
-    resolution:
-      integrity: sha1-JcfInLH5B3+IkbvmHY85Dq4lbx4=
+
   /figures/1.7.0:
+    resolution: { integrity: sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       escape-string-regexp: 1.0.5
       object-assign: 4.1.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-y+Hjr/zxzUS4DK3+0o3Hk6lwHS4=
+
   /figures/2.0.0:
+    resolution: { integrity: sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI= }
+    engines: { node: ">=4" }
     dependencies:
       escape-string-regexp: 1.0.5
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=
+
   /file-entry-cache/6.0.0:
+    resolution:
+      {
+        integrity: sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==,
+      }
+    engines: { node: ^10.12.0 || >=12.0.0 }
     dependencies:
       flat-cache: 3.0.4
     dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    resolution:
-      integrity: sha512-fqoO76jZ3ZnYrXLDRxBR1YvOvc0k844kcOg40bgsPrE25LAb/PDqTY+ho64Xh2c8ZXgIKldchCFHczG2UVRcWA==
+
   /fill-range/4.0.0:
+    resolution: { integrity: sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       extend-shallow: 2.0.1
       is-number: 3.0.0
       repeat-string: 1.6.1
       to-regex-range: 2.1.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=
+
   /fill-range/7.0.1:
+    resolution:
+      {
+        integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       to-regex-range: 5.0.1
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==
+
   /find-up/3.0.0:
+    resolution:
+      {
+        integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       locate-path: 3.0.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-1yD6RmLI1XBfxugvORwlck6f75tYL+iR0jqwsOrOxMZyGYqUuDhJ0l4AXdO1iX/FTs9cBAMEk1gWSEx1kSbylg==
+
   /find-up/4.1.0:
+    resolution:
+      {
+        integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       locate-path: 5.0.0
       path-exists: 4.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==
+
   /find-up/5.0.0:
+    resolution:
+      {
+        integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       locate-path: 6.0.0
       path-exists: 4.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng==
+
   /find-versions/4.0.0:
+    resolution:
+      {
+        integrity: sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       semver-regex: 3.1.2
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-wgpWy002tA+wgmO27buH/9KzyEOQnKsG/R0yrcjPT9BOFm0zRBVQbZ95nRGXWMywS8YR5knRbpohio0bcJABxQ==
+
   /flat-cache/3.0.4:
+    resolution:
+      {
+        integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==,
+      }
+    engines: { node: ^10.12.0 || >=12.0.0 }
     dependencies:
       flatted: 3.1.1
       rimraf: 3.0.2
     dev: true
-    engines:
-      node: ^10.12.0 || >=12.0.0
-    resolution:
-      integrity: sha512-dm9s5Pw7Jc0GvMYbshN6zchCA9RgQlzzEZX3vylR9IqFfS8XciblUXOKfW6SiuJ0e13eDYZoZV5wdrev7P3Nwg==
+
   /flatted/3.1.1:
-    dev: true
     resolution:
-      integrity: sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==
+      {
+        integrity: sha512-zAoAQiudy+r5SvnSw3KJy5os/oRJYHzrzja/tBDqrZtNhUw8bt6y8OBzMWcjWr+8liV8Eb6yOhw8WZ7VFZ5ZzA==,
+      }
+    dev: true
+
   /for-in/1.0.2:
+    resolution: { integrity: sha1-gQaNKVqBQuwKxybG4iAMMPttXoA= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-gQaNKVqBQuwKxybG4iAMMPttXoA=
+
   /forever-agent/0.6.1:
+    resolution: { integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE= }
     dev: true
-    resolution:
-      integrity: sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=
+
   /form-data/2.3.3:
+    resolution:
+      {
+        integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==,
+      }
+    engines: { node: ">= 0.12" }
     dependencies:
       asynckit: 0.4.0
       combined-stream: 1.0.8
       mime-types: 2.1.28
     dev: true
-    engines:
-      node: ">= 0.12"
-    resolution:
-      integrity: sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==
+
   /fragment-cache/0.2.1:
+    resolution: { integrity: sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       map-cache: 0.2.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=
+
   /fs-extra/9.1.0:
+    resolution:
+      {
+        integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       at-least-node: 1.0.0
       graceful-fs: 4.2.4
       jsonfile: 6.1.0
       universalify: 2.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-hcg3ZmepS30/7BSFqRvoo3DOMQu7IjqxO5nCDt+zM9XWjb33Wg7ziNT+Qvqbuc3+gWpzO02JubVyk2G4Zvo1OQ==
+
   /fs-minipass/2.1.0:
+    resolution:
+      {
+        integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==,
+      }
+    engines: { node: ">= 8" }
     dependencies:
       minipass: 3.1.3
     dev: true
-    engines:
-      node: ">= 8"
-    resolution:
-      integrity: sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==
+
   /fs.realpath/1.0.0:
+    resolution: { integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8= }
     dev: true
-    resolution:
-      integrity: sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
+
   /fsevents/2.1.3:
+    resolution:
+      {
+        integrity: sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
     deprecated: '"Please update to latest v2.3 or v2.2"'
     dev: true
-    engines:
-      node: ^8.16.0 || ^10.6.0 || >=11.0.0
     optional: true
-    os:
-      - darwin
-    resolution:
-      integrity: sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==
+
   /fsevents/2.3.1:
+    resolution:
+      {
+        integrity: sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==,
+      }
+    engines: { node: ^8.16.0 || ^10.6.0 || >=11.0.0 }
+    os: [darwin]
     dev: true
-    engines:
-      node: ^8.16.0 || ^10.6.0 || >=11.0.0
     optional: true
-    os:
-      - darwin
-    resolution:
-      integrity: sha512-YR47Eg4hChJGAB1O3yEAOkGO+rlzutoICGqGo9EZ4lKWokzZRSyIW1QmTzqjtw8MJdj9srP869CuWw/hyzSiBw==
+
   /function-bind/1.1.1:
-    dev: true
     resolution:
-      integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+      {
+        integrity: sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==,
+      }
+    dev: true
+
   /functional-red-black-tree/1.0.1:
+    resolution: { integrity: sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc= }
     dev: true
-    resolution:
-      integrity: sha1-GwqzvVU7Kg1jmdKcDj6gslIHgyc=
+
   /gauge/2.7.4:
+    resolution: { integrity: sha1-LANAXHU4w51+s3sxcCLjJfsBi/c= }
     dependencies:
       aproba: 1.2.0
       console-control-strings: 1.1.0
@@ -3720,77 +4724,97 @@ packages:
       strip-ansi: 3.0.1
       wide-align: 1.1.3
     dev: true
-    resolution:
-      integrity: sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=
+
   /gensync/1.0.0-beta.2:
-    dev: true
-    engines:
-      node: ">=6.9.0"
     resolution:
-      integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==
+      {
+        integrity: sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==,
+      }
+    engines: { node: ">=6.9.0" }
+    dev: true
+
   /get-caller-file/2.0.5:
-    dev: true
-    engines:
-      node: 6.* || 8.* || >= 10.*
     resolution:
-      integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
+      {
+        integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==,
+      }
+    engines: { node: 6.* || 8.* || >= 10.* }
+    dev: true
+
   /get-intrinsic/1.0.2:
+    resolution:
+      {
+        integrity: sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==,
+      }
     dependencies:
       function-bind: 1.1.1
       has: 1.0.3
       has-symbols: 1.0.1
     dev: true
-    resolution:
-      integrity: sha512-aeX0vrFm21ILl3+JpFFRNe9aUvp6VFZb2/CTbgLb8j75kOhvoNYjt9d8KA/tJG4gSo8nzEDedRl0h7vDmBYRVg==
+
   /get-package-type/0.1.0:
-    dev: true
-    engines:
-      node: ">=8.0.0"
     resolution:
-      integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==
+      {
+        integrity: sha512-pjzuKtY64GYfWizNAJ0fr9VqttZkNiK2iS430LtIHzjBEr6bX8Am2zm4sW4Ro5wjWW5cAlRL1qAMTcXbjNAO2Q==,
+      }
+    engines: { node: ">=8.0.0" }
+    dev: true
+
   /get-stream/4.1.0:
+    resolution:
+      {
+        integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       pump: 3.0.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==
+
   /get-stream/5.2.0:
+    resolution:
+      {
+        integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       pump: 3.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==
+
   /get-value/2.0.6:
+    resolution: { integrity: sha1-3BXKHGcjh8p2vTesCjlbogQqLCg= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-3BXKHGcjh8p2vTesCjlbogQqLCg=
+
   /getos/3.2.1:
+    resolution:
+      {
+        integrity: sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==,
+      }
     dependencies:
       async: 3.2.0
     dev: true
-    resolution:
-      integrity: sha512-U56CfOK17OKgTVqozZjUKNdkfEv6jk5WISBJ8SHoagjE6L69zOwl3Z+O8myjY9MEW3i2HPWQBt/LTbCgcC973Q==
+
   /getpass/0.1.7:
+    resolution: { integrity: sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo= }
     dependencies:
       assert-plus: 1.0.0
     dev: true
-    resolution:
-      integrity: sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=
+
   /glob-parent/5.1.1:
+    resolution:
+      {
+        integrity: sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==,
+      }
+    engines: { node: ">= 6" }
     dependencies:
       is-glob: 4.0.1
     dev: true
-    engines:
-      node: ">= 6"
-    resolution:
-      integrity: sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==
+
   /glob/7.1.6:
+    resolution:
+      {
+        integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==,
+      }
     dependencies:
       fs.realpath: 1.0.0
       inflight: 1.0.6
@@ -3799,31 +4823,41 @@ packages:
       once: 1.4.0
       path-is-absolute: 1.0.1
     dev: true
-    resolution:
-      integrity: sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
+
   /global-dirs/2.1.0:
+    resolution:
+      {
+        integrity: sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       ini: 1.3.7
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-MG6kdOUh/xBnyo9cJFeIKkLEc1AyFq42QTU4XiX51i2NEdxLxLWXIjEjmqKeSuKR7pAZjTqUVoT2b2huxVLgYQ==
+
   /globals/11.12.0:
-    dev: true
-    engines:
-      node: ">=4"
     resolution:
-      integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==
+      {
+        integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /globals/12.4.0:
+    resolution:
+      {
+        integrity: sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       type-fest: 0.8.1
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-BWICuzzDvDoH54NHKCseDanAhE3CeDorgDL5MT6LMXXj2WCnd9UC2szdk4AWLfjdgNBCXLUanXYcpBBKOSWGwg==
+
   /globby/11.0.2:
+    resolution:
+      {
+        integrity: sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       array-union: 2.1.0
       dir-glob: 3.0.1
@@ -3832,11 +4866,13 @@ packages:
       merge2: 1.4.1
       slash: 3.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-2ZThXDvvV8fYFRVIxnrMQBipZQDr7MxKAmQK1vujaj9/7eF0efG7BPUKJ7jP7G5SLF37xKDXvO4S/KKLj/Z0og==
+
   /got/9.6.0:
+    resolution:
+      {
+        integrity: sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==,
+      }
+    engines: { node: ">=8.6" }
     dependencies:
       "@sindresorhus/is": 0.14.0
       "@szmarczak/http-timer": 1.1.2
@@ -3850,145 +4886,164 @@ packages:
       to-readable-stream: 1.0.0
       url-parse-lax: 3.0.0
     dev: true
-    engines:
-      node: ">=8.6"
-    resolution:
-      integrity: sha512-R7eWptXuGYxwijs0eV+v3o6+XH1IqVK8dJOEecQfTmkncw9AV4dcw/Dhxi8MdlqPthxxpZyizMzyg8RTmEsG+Q==
+
   /graceful-fs/4.2.4:
-    dev: true
     resolution:
-      integrity: sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
+      {
+        integrity: sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==,
+      }
+    dev: true
+
   /growly/1.3.0:
+    resolution: { integrity: sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE= }
     dev: true
     optional: true
-    resolution:
-      integrity: sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
+
   /har-schema/2.0.0:
+    resolution: { integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=
+
   /har-validator/5.1.5:
+    resolution:
+      {
+        integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==,
+      }
+    engines: { node: ">=6" }
+    deprecated: this library is no longer supported
     dependencies:
       ajv: 6.12.6
       har-schema: 2.0.0
-    deprecated: this library is no longer supported
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==
+
   /hard-rejection/2.1.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==
+      {
+        integrity: sha512-VIZB+ibDhx7ObhAe7OVtoEbuP4h/MuOTHJ+J8h/eBXotJYl0fBgR72xDFCKgIh22OJZIOVNxBMWuhAr10r8HdA==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /has-ansi/2.0.0:
+    resolution: { integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       ansi-regex: 2.1.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=
+
   /has-flag/3.0.0:
+    resolution: { integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-tdRU3CGZriJWmfNGfloH87lVuv0=
+
   /has-flag/4.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==
+      {
+        integrity: sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /has-symbols/1.0.1:
-    dev: true
-    engines:
-      node: ">= 0.4"
     resolution:
-      integrity: sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==
+      {
+        integrity: sha512-PLcsoqu++dmEIZB+6totNFKq/7Do+Z0u4oT0zKOJNl3lYK6vGwwu2hjHs+68OEZbTjiUE9bgOABXbP/GvrS0Kg==,
+      }
+    engines: { node: ">= 0.4" }
+    dev: true
+
   /has-unicode/2.0.1:
+    resolution: { integrity: sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk= }
     dev: true
-    resolution:
-      integrity: sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=
+
   /has-value/0.3.1:
+    resolution: { integrity: sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       get-value: 2.0.6
       has-values: 0.1.4
       isobject: 2.1.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=
+
   /has-value/1.0.0:
+    resolution: { integrity: sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       get-value: 2.0.6
       has-values: 1.0.0
       isobject: 3.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=
+
   /has-values/0.1.4:
+    resolution: { integrity: sha1-bWHeldkd/Km5oCCJrThL/49it3E= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-bWHeldkd/Km5oCCJrThL/49it3E=
+
   /has-values/1.0.0:
+    resolution: { integrity: sha1-lbC2P+whRmGab+V/51Yo1aOe/k8= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-number: 3.0.0
       kind-of: 4.0.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=
+
   /has-yarn/2.1.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==
+      {
+        integrity: sha512-UqBRqi4ju7T+TqGNdqAO0PaSVGsDGJUBQvk9eUWNGRY1CFGDzYhLWoM7JQEemnlvVcv/YEmc2wNW8BC24EnUsw==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /has/1.0.3:
+    resolution:
+      {
+        integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==,
+      }
+    engines: { node: ">= 0.4.0" }
     dependencies:
       function-bind: 1.1.1
     dev: true
-    engines:
-      node: ">= 0.4.0"
-    resolution:
-      integrity: sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==
+
   /hosted-git-info/2.8.8:
-    dev: true
     resolution:
-      integrity: sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==
+      {
+        integrity: sha512-f/wzC2QaWBs7t9IYqB4T3sR1xviIViXJRJTWBlx2Gf3g0Xi5vI7Yy4koXQ1c9OYDGHN9sBy1DQ2AB8fqZBWhUg==,
+      }
+    dev: true
+
   /hosted-git-info/3.0.7:
+    resolution:
+      {
+        integrity: sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       lru-cache: 6.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-fWqc0IcuXs+BmE9orLDyVykAG9GJtGLGuZAAqgcckPgv5xad4AcXGIv8galtQvlwutxSlaMcdw7BUtq2EIvqCQ==
+
   /html-encoding-sniffer/2.0.1:
+    resolution:
+      {
+        integrity: sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       whatwg-encoding: 1.0.5
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-D5JbOMBIR/TVZkubHT+OyT2705QvogUW4IBn6nHd756OwieSF9aDYFj4dv6HHEVGYbHaLETa3WggZYWWMyy3ZQ==
+
   /html-escaper/2.0.2:
-    dev: true
     resolution:
-      integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==
+      {
+        integrity: sha512-H2iMtd0I4Mt5eYiapRdIDjp+XzelXQ0tFE4JS7YFwFevXXMmOp9myNrUvCg0D6ws8iqkRPBfKHgbwig1SmlLfg==,
+      }
+    dev: true
+
   /htmlparser2/3.10.1:
+    resolution:
+      {
+        integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==,
+      }
     dependencies:
       domelementtype: 1.3.1
       domhandler: 2.4.2
@@ -3997,55 +5052,72 @@ packages:
       inherits: 2.0.4
       readable-stream: 3.6.0
     dev: true
-    resolution:
-      integrity: sha512-IgieNijUMbkDovyoKObU1DUhm1iwNYE/fuifEoEHfd1oZKZDaONBSkal7Y01shxsM49R4XaMdGez3WnF9UfiCQ==
+
   /http-cache-semantics/4.1.0:
-    dev: true
     resolution:
-      integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==
+      {
+        integrity: sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==,
+      }
+    dev: true
+
   /http-proxy-agent/4.0.1:
+    resolution:
+      {
+        integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==,
+      }
+    engines: { node: ">= 6" }
     dependencies:
       "@tootallnate/once": 1.1.2
       agent-base: 6.0.2
       debug: 4.3.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">= 6"
-    resolution:
-      integrity: sha512-k0zdNgqWTGA6aeIRVpvfVob4fL52dTfaehylg0Y4UvSySvOq/Y+BOyPrgpUrA7HylqvU8vIZGsRuXmspskV0Tg==
+
   /http-signature/1.2.0:
+    resolution: { integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE= }
+    engines: { node: ">=0.8", npm: ">=1.3.7" }
     dependencies:
       assert-plus: 1.0.0
       jsprim: 1.4.1
       sshpk: 1.16.1
     dev: true
-    engines:
-      node: ">=0.8"
-      npm: ">=1.3.7"
-    resolution:
-      integrity: sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=
+
   /https-proxy-agent/5.0.0:
+    resolution:
+      {
+        integrity: sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==,
+      }
+    engines: { node: ">= 6" }
     dependencies:
       agent-base: 6.0.2
       debug: 4.3.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">= 6"
-    resolution:
-      integrity: sha512-EkYm5BcKUGiduxzSt3Eppko+PiNWNEpa4ySk9vTC6wDsQJW9rHSa+UhGNJoRYp7bz6Ht1eaRIa6QaJqO5rCFbA==
+
   /human-signals/1.1.1:
-    dev: true
-    engines:
-      node: ">=8.12.0"
     resolution:
-      integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
+      {
+        integrity: sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==,
+      }
+    engines: { node: ">=8.12.0" }
+    dev: true
+
   /humanize-ms/1.2.1:
+    resolution: { integrity: sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0= }
     dependencies:
       ms: 2.1.3
     dev: true
-    resolution:
-      integrity: sha1-xG4xWaKT9riW2ikxbYtv6Lt5u+0=
+
   /husky/4.3.8:
+    resolution:
+      {
+        integrity: sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
+    requiresBuild: true
     dependencies:
       chalk: 4.1.0
       ci-info: 2.0.0
@@ -4058,501 +5130,600 @@ packages:
       slash: 3.0.0
       which-pm-runs: 1.0.0
     dev: true
-    engines:
-      node: ">=10"
-    hasBin: true
-    requiresBuild: true
-    resolution:
-      integrity: sha512-LCqqsB0PzJQ/AlCgfrfzRe3e3+NvmefAdKQhRYpxS4u6clblBoDdzzvHi8fmxKRzvMxPY/1WZWzomPZww0Anow==
+
   /iconv-lite/0.4.24:
+    resolution:
+      {
+        integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       safer-buffer: 2.1.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
+
   /iconv-lite/0.6.2:
+    resolution:
+      {
+        integrity: sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       safer-buffer: 2.1.2
     dev: true
-    engines:
-      node: ">=0.10.0"
     optional: true
-    resolution:
-      integrity: sha512-2y91h5OpQlolefMPmUlivelittSWy0rP+oYVpn6A7GwVHNE8AWzoYOBNmlwks3LobaJxgHCYZAnyNo2GgpNRNQ==
+
   /ignore-walk/3.0.3:
+    resolution:
+      {
+        integrity: sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==,
+      }
     dependencies:
       minimatch: 3.0.4
     dev: true
-    resolution:
-      integrity: sha512-m7o6xuOaT1aqheYHKf8W6J5pYH85ZI9w077erOzLje3JsB1gkafkAhHHY19dqjulgIZHFm32Cp5uNZgcQqdJKw==
+
   /ignore/4.0.6:
-    dev: true
-    engines:
-      node: ">= 4"
     resolution:
-      integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==
+      {
+        integrity: sha512-cyFDKrqc/YdcWFniJhzI42+AzS+gNwmUzOSFcRCQYwySuBBBy/KjuxWLZ/FHEH6Moq1NizMOBWyTcv8O4OZIMg==,
+      }
+    engines: { node: ">= 4" }
+    dev: true
+
   /ignore/5.1.8:
-    dev: true
-    engines:
-      node: ">= 4"
     resolution:
-      integrity: sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==
+      {
+        integrity: sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==,
+      }
+    engines: { node: ">= 4" }
+    dev: true
+
   /import-fresh/3.3.0:
+    resolution:
+      {
+        integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       parent-module: 1.0.1
       resolve-from: 4.0.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-veYYhQa+D1QBKznvhUHxb8faxlrwUnxseDAbAp457E0wLNio2bOSKnjYDhMj+YiAq61xrMGhQk9iXVk5FzgQMw==
+
   /import-lazy/2.1.0:
+    resolution: { integrity: sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-BWmOPUXIjo1+nZLLBYTnfwlvPkM=
+
   /import-local/3.0.2:
+    resolution:
+      {
+        integrity: sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==,
+      }
+    engines: { node: ">=8" }
+    hasBin: true
     dependencies:
       pkg-dir: 4.2.0
       resolve-cwd: 3.0.0
     dev: true
-    engines:
-      node: ">=8"
-    hasBin: true
-    resolution:
-      integrity: sha512-vjL3+w0oulAVZ0hBHnxa/Nm5TAurf9YLQJDhqRZyqb+VKGOB6LU8t9H1Nr5CIo16vh9XfJTOoHwU0B71S557gA==
+
   /imurmurhash/0.1.4:
+    resolution: { integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o= }
+    engines: { node: ">=0.8.19" }
     dev: true
-    engines:
-      node: ">=0.8.19"
-    resolution:
-      integrity: sha1-khi5srkoojixPcT7a21XbyMUU+o=
+
   /indent-string/3.2.0:
+    resolution: { integrity: sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-Sl/W0nzDMvN+VBmlBNu4NxBckok=
+
   /indent-string/4.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==
+      {
+        integrity: sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /infer-owner/1.0.4:
-    dev: true
     resolution:
-      integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==
+      {
+        integrity: sha512-IClj+Xz94+d7irH5qRyfJonOdfTzuDaifE6ZPWfx0N0+/ATZCbuTPq2prFl526urkQd90WyUKIh1DfBQ2hMz9A==,
+      }
+    dev: true
+
   /inflight/1.0.6:
+    resolution: { integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk= }
     dependencies:
       once: 1.4.0
       wrappy: 1.0.2
     dev: true
-    resolution:
-      integrity: sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=
+
   /inherits/2.0.4:
-    dev: true
     resolution:
-      integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
+      {
+        integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==,
+      }
+    dev: true
+
   /ini/1.3.7:
-    dev: true
     resolution:
-      integrity: sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==
+      {
+        integrity: sha512-iKpRpXP+CrP2jyrxvg1kMUpXDyRUFDWurxbnVT1vQPx+Wz9uCYsMIqYuSBLV+PAaZG/d7kRLKRFc9oDMsH+mFQ==,
+      }
+    dev: true
+
   /ini/1.3.8:
-    dev: true
     resolution:
-      integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
+      {
+        integrity: sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==,
+      }
+    dev: true
+
   /ip-regex/2.1.0:
+    resolution: { integrity: sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk=
+
   /ip/1.1.5:
+    resolution: { integrity: sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo= }
     dev: true
-    resolution:
-      integrity: sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo=
+
   /irregular-plurals/3.2.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==
+      {
+        integrity: sha512-YqTdPLfwP7YFN0SsD3QUVCkm9ZG2VzOXv3DOrw5G5mkMbVwptTwVcFv7/C0vOpBmgTxAeTG19XpUs1E522LW9Q==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /is-accessor-descriptor/0.1.6:
+    resolution: { integrity: sha1-qeEss66Nh2cn7u84Q/igiXtcmNY= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       kind-of: 3.2.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=
+
   /is-accessor-descriptor/1.0.0:
+    resolution:
+      {
+        integrity: sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       kind-of: 6.0.3
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==
+
   /is-arrayish/0.2.1:
+    resolution: { integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0= }
     dev: true
-    resolution:
-      integrity: sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=
+
   /is-buffer/1.1.6:
-    dev: true
     resolution:
-      integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
+      {
+        integrity: sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==,
+      }
+    dev: true
+
   /is-callable/1.2.2:
-    dev: true
-    engines:
-      node: ">= 0.4"
     resolution:
-      integrity: sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
+      {
+        integrity: sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==,
+      }
+    engines: { node: ">= 0.4" }
+    dev: true
+
   /is-ci/2.0.0:
+    resolution:
+      {
+        integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==,
+      }
+    hasBin: true
     dependencies:
       ci-info: 2.0.0
     dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-YfJT7rkpQB0updsdHLGWrvhBJfcfzNNawYDNIyQXJz0IViGf75O8EBPKSdvw2rF+LGCsX4FZ8tcr3b19LcZq4w==
+
   /is-core-module/2.2.0:
+    resolution:
+      {
+        integrity: sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==,
+      }
     dependencies:
       has: 1.0.3
     dev: true
-    resolution:
-      integrity: sha512-XRAfAdyyY5F5cOXn7hYQDqh2Xmii+DEfIcQGxK/uNwMHhIkPWO0g8msXcbzLe+MpGoR951MlqM/2iIlU4vKDdQ==
+
   /is-data-descriptor/0.1.4:
+    resolution: { integrity: sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       kind-of: 3.2.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=
+
   /is-data-descriptor/1.0.0:
+    resolution:
+      {
+        integrity: sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       kind-of: 6.0.3
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
+
   /is-date-object/1.0.2:
-    dev: true
-    engines:
-      node: ">= 0.4"
     resolution:
-      integrity: sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
+      {
+        integrity: sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==,
+      }
+    engines: { node: ">= 0.4" }
+    dev: true
+
   /is-descriptor/0.1.6:
+    resolution:
+      {
+        integrity: sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-accessor-descriptor: 0.1.6
       is-data-descriptor: 0.1.4
       kind-of: 5.1.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==
+
   /is-descriptor/1.0.2:
+    resolution:
+      {
+        integrity: sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-accessor-descriptor: 1.0.0
       is-data-descriptor: 1.0.0
       kind-of: 6.0.3
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==
+
   /is-docker/2.1.1:
-    dev: true
-    engines:
-      node: ">=8"
+    resolution:
+      {
+        integrity: sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==,
+      }
+    engines: { node: ">=8" }
     hasBin: true
-    optional: true
-    resolution:
-      integrity: sha512-ZOoqiXfEwtGknTiuDEy8pN2CfE3TxMHprvNer1mXiqwkOT77Rw3YVrUQ52EqAOU3QAWDQ+bQdx7HJzrv7LS2Hw==
-  /is-extendable/0.1.1:
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik=
+    optional: true
+
+  /is-extendable/0.1.1:
+    resolution: { integrity: sha1-YrEQ4omkcUGOPsNqYX1HLjAd/Ik= }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /is-extendable/1.0.1:
+    resolution:
+      {
+        integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-plain-object: 2.0.4
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==
+
   /is-extglob/2.1.1:
+    resolution: { integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=
+
   /is-fullwidth-code-point/1.0.0:
+    resolution: { integrity: sha1-754xOG8DGn8NZDr4L95QxFfvAMs= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       number-is-nan: 1.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-754xOG8DGn8NZDr4L95QxFfvAMs=
+
   /is-fullwidth-code-point/2.0.0:
+    resolution: { integrity: sha1-o7MKXE8ZkYMWeqq5O+764937ZU8= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-o7MKXE8ZkYMWeqq5O+764937ZU8=
+
   /is-fullwidth-code-point/3.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==
+      {
+        integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /is-generator-fn/2.1.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==
+      {
+        integrity: sha512-cTIB4yPYL/Grw0EaSzASzg6bBy9gqCofvWN8okThAYIxKJZC+udlRAmGbM0XLeniEJSs8uEgHPGuHSe1XsOLSQ==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /is-glob/4.0.1:
+    resolution:
+      {
+        integrity: sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-extglob: 2.1.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==
+
   /is-installed-globally/0.3.2:
+    resolution:
+      {
+        integrity: sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       global-dirs: 2.1.0
       is-path-inside: 3.0.2
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-wZ8x1js7Ia0kecP/CHM/3ABkAmujX7WPvQk6uu3Fly/Mk44pySulQpnHG46OMjHGXApINnV4QhY3SWnECO2z5g==
+
   /is-lambda/1.0.1:
+    resolution: { integrity: sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU= }
     dev: true
-    resolution:
-      integrity: sha1-PZh3iZ5qU+/AFgUEzeFfgubwYdU=
+
   /is-module/1.0.0:
+    resolution: { integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE= }
     dev: true
-    resolution:
-      integrity: sha1-Mlj7afeMFNW4FdZkM2tM/7ZEFZE=
+
   /is-negative-zero/2.0.1:
-    dev: true
-    engines:
-      node: ">= 0.4"
     resolution:
-      integrity: sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==
+      {
+        integrity: sha512-2z6JzQvZRa9A2Y7xC6dQQm4FSTSTNWjKIYYTt4246eMTJmIo0Q+ZyOsU66X8lxK1AbB92dFeglPLrhwpeRKO6w==,
+      }
+    engines: { node: ">= 0.4" }
+    dev: true
+
   /is-npm/4.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==
+      {
+        integrity: sha512-96ECIfh9xtDDlPylNPXhzjsykHsMJZ18ASpaWzQyBr4YRTcVjUvzaHayDAES2oU/3KpljhHUjtSRNiDwi0F0ig==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /is-number/3.0.0:
+    resolution: { integrity: sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       kind-of: 3.2.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=
+
   /is-number/7.0.0:
-    dev: true
-    engines:
-      node: ">=0.12.0"
     resolution:
-      integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
+      {
+        integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==,
+      }
+    engines: { node: ">=0.12.0" }
+    dev: true
+
   /is-obj/2.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==
+      {
+        integrity: sha512-drqDG3cbczxxEJRoOXcOjtdp1J/lyp1mNn0xaznRs8+muBhgQcrnbspox5X5fOw0HnMnbfDzvnEMEtqDEJEo8w==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /is-observable/1.1.0:
+    resolution:
+      {
+        integrity: sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==,
+      }
+    engines: { node: ">=4" }
     dependencies:
       symbol-observable: 1.2.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha512-NqCa4Sa2d+u7BWc6CukaObG3Fh+CU9bvixbpcXYhy2VvYS7vVGIdAgnIS5Ks3A/cqk4rebLJ9s8zBstT2aKnIA==
+
   /is-path-inside/3.0.2:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==
+      {
+        integrity: sha512-/2UGPSgmtqwo1ktx8NDHjuPwZWmHhO+gj0f93EkhLB5RgW9RZevWYYlIkS6zePc6U2WpOdQYIwHe9YC4DWEBVg==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /is-plain-obj/1.1.0:
+    resolution: { integrity: sha1-caUMhCnfync8kqOQpKA7OfzVHT4= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-caUMhCnfync8kqOQpKA7OfzVHT4=
+
   /is-plain-object/2.0.4:
+    resolution:
+      {
+        integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       isobject: 3.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==
+
   /is-potential-custom-element-name/1.0.0:
+    resolution: { integrity: sha1-DFLlS8yjkbssSUsh6GJtczbG45c= }
     dev: true
-    resolution:
-      integrity: sha1-DFLlS8yjkbssSUsh6GJtczbG45c=
+
   /is-promise/2.2.2:
-    dev: true
     resolution:
-      integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
+      {
+        integrity: sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==,
+      }
+    dev: true
+
   /is-reference/1.2.1:
+    resolution:
+      {
+        integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==,
+      }
     dependencies:
       "@types/estree": 0.0.46
     dev: true
-    resolution:
-      integrity: sha512-U82MsXXiFIrjCK4otLT+o2NA2Cd2g5MLoOVXUZjIOhLurrRxpEXzI8O0KZHr3IjLvlAH1kTPYSuqer5T9ZVBKQ==
+
   /is-regex/1.1.1:
+    resolution:
+      {
+        integrity: sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==,
+      }
+    engines: { node: ">= 0.4" }
     dependencies:
       has-symbols: 1.0.1
     dev: true
-    engines:
-      node: ">= 0.4"
-    resolution:
-      integrity: sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
+
   /is-stream/1.1.0:
+    resolution: { integrity: sha1-EtSj3U5o4Lec6428hBc66A2RykQ= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
+
   /is-stream/2.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
+      {
+        integrity: sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /is-symbol/1.0.3:
+    resolution:
+      {
+        integrity: sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==,
+      }
+    engines: { node: ">= 0.4" }
     dependencies:
       has-symbols: 1.0.1
     dev: true
-    engines:
-      node: ">= 0.4"
-    resolution:
-      integrity: sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
+
   /is-typedarray/1.0.0:
+    resolution: { integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo= }
     dev: true
-    resolution:
-      integrity: sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=
+
   /is-windows/1.0.2:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==
+      {
+        integrity: sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /is-wsl/2.2.0:
+    resolution:
+      {
+        integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       is-docker: 2.1.1
     dev: true
-    engines:
-      node: ">=8"
     optional: true
-    resolution:
-      integrity: sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
+
   /is-yarn-global/0.3.0:
-    dev: true
     resolution:
-      integrity: sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==
+      {
+        integrity: sha512-VjSeb/lHmkoyd8ryPVIKvOCn4D1koMqY+vqyjjUfc3xyKtP4dYOxM44sZrnqQSzSds3xyOrUTLTC9LVCVgLngw==,
+      }
+    dev: true
+
   /isarray/1.0.0:
+    resolution: { integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE= }
     dev: true
-    resolution:
-      integrity: sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=
+
   /isexe/2.0.0:
+    resolution: { integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA= }
     dev: true
-    resolution:
-      integrity: sha1-6PvzdNxVb/iUehDcsFctYz8s+hA=
+
   /isobject/2.1.0:
+    resolution: { integrity: sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       isarray: 1.0.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=
+
   /isobject/3.0.1:
+    resolution: { integrity: sha1-TkMekrEalzFjaqH5yNHMvP2reN8= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
+
   /isstream/0.1.2:
+    resolution: { integrity: sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo= }
     dev: true
-    resolution:
-      integrity: sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=
+
   /istanbul-lib-coverage/3.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==
+      {
+        integrity: sha512-UiUIqxMgRDET6eR+o5HbfRYP1l0hqkWOs7vNxC/mggutCMUIhWMm8gAHb8tHlyfD3/l6rlgNA5cKdDzEAf6hEg==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /istanbul-lib-instrument/4.0.3:
+    resolution:
+      {
+        integrity: sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       "@babel/core": 7.12.10
       "@istanbuljs/schema": 0.1.2
       istanbul-lib-coverage: 3.0.0
       semver: 6.3.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-BXgQl9kf4WTCPCCpmFGoJkz/+uhvm7h7PFKUYxh7qarQd3ER33vHG//qaE8eN25l07YqZPpHXU9I09l/RD5aGQ==
+
   /istanbul-lib-report/3.0.0:
+    resolution:
+      {
+        integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       istanbul-lib-coverage: 3.0.0
       make-dir: 3.1.0
       supports-color: 7.2.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-wcdi+uAKzfiGT2abPpKZ0hSU1rGQjUQnLvtY5MpQ7QCTahD3VODhcu4wcfY1YtkGaDD5yuydOLINXsfbus9ROw==
+
   /istanbul-lib-source-maps/4.0.0:
+    resolution:
+      {
+        integrity: sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       debug: 4.3.1
       istanbul-lib-coverage: 3.0.0
       source-map: 0.6.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-c16LpFRkR8vQXyHZ5nLpY35JZtzj1PQY1iZmesUbf1FZHbIupcWfjgOXBY9YHkLEQ6puz1u4Dgj6qmU/DisrZg==
+
   /istanbul-reports/3.0.2:
+    resolution:
+      {
+        integrity: sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       html-escaper: 2.0.2
       istanbul-lib-report: 3.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-9tZvz7AiR3PEDNGiV9vIouQ/EAcqMXFmkcA1CDFTwOB98OZVDL0PH9glHotf5Ugp6GCOTypfzGWI/OqjWNCRUw==
+
   /jest-changed-files/26.6.2:
+    resolution:
+      {
+        integrity: sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/types": 26.6.2
       execa: 4.1.0
       throat: 5.0.0
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-fDS7szLcY9sCtIip8Fjry9oGf3I2ht/QT21bAHm5Dmf0mD4X3ReNUf17y+bO6fR8WgbIZTlbyG1ak/53cbRzKQ==
+
   /jest-cli/26.6.3:
+    resolution:
+      {
+        integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==,
+      }
+    engines: { node: ">= 10.14.2" }
+    hasBin: true
     dependencies:
       "@jest/core": 26.6.3
       "@jest/test-result": 26.6.2
@@ -4567,13 +5738,25 @@ packages:
       jest-validate: 26.6.2
       prompts: 2.4.0
       yargs: 15.4.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    hasBin: true
-    resolution:
-      integrity: sha512-GF9noBSa9t08pSyl3CY4frMrqp+aQXFGFkf5hEPbh/pIUFYWMK6ZLTfbmadxJVcJrdRoChlWQsA2VkJcDFK8hg==
+
   /jest-config/26.6.3:
+    resolution:
+      {
+        integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==,
+      }
+    engines: { node: ">= 10.14.2" }
+    peerDependencies:
+      ts-node: ">=9.0.0"
+    peerDependenciesMeta:
+      ts-node:
+        optional: true
     dependencies:
       "@babel/core": 7.12.10
       "@jest/test-sequencer": 26.6.3
@@ -4593,36 +5776,42 @@ packages:
       jest-validate: 26.6.2
       micromatch: 4.0.2
       pretty-format: 26.6.2
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - utf-8-validate
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    peerDependencies:
-      ts-node: ">=9.0.0"
-    peerDependenciesMeta:
-      ts-node:
-        optional: true
-    resolution:
-      integrity: sha512-t5qdIj/bCj2j7NFVHb2nFB4aUdfucDn3JRKgrZnplb8nieAirAzRSHP8uDEd+qV6ygzg9Pz4YG7UTJf94LPSyg==
+
   /jest-diff/26.6.2:
+    resolution:
+      {
+        integrity: sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       chalk: 4.1.0
       diff-sequences: 26.6.2
       jest-get-type: 26.3.0
       pretty-format: 26.6.2
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-6m+9Z3Gv9wN0WFVasqjCL/06+EFCMTqDEUl/b87HYK2rAPTyfz4ZIuSlPhY51PIQRWx5TaxeF1qmXKe9gfN3sA==
+
   /jest-docblock/26.0.0:
+    resolution:
+      {
+        integrity: sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       detect-newline: 3.1.0
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-RDZ4Iz3QbtRWycd8bUEPxQsTlYazfYn/h5R65Fc6gOfwozFhoImx+affzky/FFBuqISPTqjXomoIGJVKBWoo0w==
+
   /jest-each/26.6.2:
+    resolution:
+      {
+        integrity: sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/types": 26.6.2
       chalk: 4.1.0
@@ -4630,11 +5819,13 @@ packages:
       jest-util: 26.6.2
       pretty-format: 26.6.2
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-Mer/f0KaATbjl8MCJ+0GEpNdqmnVmDYqCTJYTvoo7rqmRiDllmp2AYN+06F93nXcY3ur9ShIjS+CO/uD+BbH4A==
+
   /jest-environment-jsdom/26.6.2:
+    resolution:
+      {
+        integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/environment": 26.6.2
       "@jest/fake-timers": 26.6.2
@@ -4643,12 +5834,18 @@ packages:
       jest-mock: 26.6.2
       jest-util: 26.6.2
       jsdom: 16.4.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - utf-8-validate
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-jgPqCruTlt3Kwqg5/WVFyHIOJHsiAvhcp2qiR2QQstuG9yWox5+iHpU3ZrcBxW14T4fe5Z68jAfLRh7joCSP2Q==
+
   /jest-environment-node/26.6.2:
+    resolution:
+      {
+        integrity: sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/environment": 26.6.2
       "@jest/fake-timers": 26.6.2
@@ -4657,17 +5854,21 @@ packages:
       jest-mock: 26.6.2
       jest-util: 26.6.2
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-zhtMio3Exty18dy8ee8eJ9kjnRyZC1N4C1Nt/VShN1apyXc8rWGtJ9lI7vqiWcyyXS4BVSEn9lxAM2D+07/Tag==
+
   /jest-get-type/26.3.0:
-    dev: true
-    engines:
-      node: ">= 10.14.2"
     resolution:
-      integrity: sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==
+      {
+        integrity: sha512-TpfaviN1R2pQWkIihlfEanwOXK0zcxrKEE4MlU6Tn7keoXdN6/3gK/xl0yEh8DOunn5pOVGKf8hB4R9gVh04ig==,
+      }
+    engines: { node: ">= 10.14.2" }
+    dev: true
+
   /jest-haste-map/26.6.2:
+    resolution:
+      {
+        integrity: sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/types": 26.6.2
       "@types/graceful-fs": 4.1.4
@@ -4682,14 +5883,16 @@ packages:
       micromatch: 4.0.2
       sane: 4.1.0
       walker: 1.0.7
-    dev: true
-    engines:
-      node: ">= 10.14.2"
     optionalDependencies:
       fsevents: 2.3.1
-    resolution:
-      integrity: sha512-easWIJXIw71B2RdR8kgqpjQrbMRWQBgiBwXYEhtGUTaX+doCjBheluShdDMeR8IMfJiTqH4+zfhtg29apJf/8w==
+    dev: true
+
   /jest-jasmine2/26.6.3:
+    resolution:
+      {
+        integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@babel/traverse": 7.12.12
       "@jest/environment": 26.6.2
@@ -4709,32 +5912,44 @@ packages:
       jest-util: 26.6.2
       pretty-format: 26.6.2
       throat: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-kPKUrQtc8aYwBV7CqBg5pu+tmYXlvFlSFYn18ev4gPFtrRzB15N2gW/Roew3187q2w2eHuu0MU9TJz6w0/nPEg==
+
   /jest-leak-detector/26.6.2:
+    resolution:
+      {
+        integrity: sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       jest-get-type: 26.3.0
       pretty-format: 26.6.2
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-i4xlXpsVSMeKvg2cEKdfhh0H39qlJlP5Ex1yQxwF9ubahboQYMgTtz5oML35AVA3B4Eu+YsmwaiKVev9KCvLxg==
+
   /jest-matcher-utils/26.6.2:
+    resolution:
+      {
+        integrity: sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       chalk: 4.1.0
       jest-diff: 26.6.2
       jest-get-type: 26.3.0
       pretty-format: 26.6.2
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-llnc8vQgYcNqDrqRDXWwMr9i7rS5XFiCwvh6DTP7Jqa2mqpcCBBlpCbn+trkG0KNhPu/h8rzyBkriOtBstvWhw==
+
   /jest-message-util/26.6.2:
+    resolution:
+      {
+        integrity: sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@babel/code-frame": 7.12.11
       "@jest/types": 26.6.2
@@ -4746,49 +5961,59 @@ packages:
       slash: 3.0.0
       stack-utils: 2.0.3
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-rGiLePzQ3AzwUshu2+Rn+UMFk0pHN58sOG+IaJbk5Jxuqo3NYO1U2/MIR4S1sKgsoYSXSzdtSa0TgrmtUwEbmA==
+
   /jest-mock/26.6.2:
+    resolution:
+      {
+        integrity: sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/types": 26.6.2
       "@types/node": 14.14.22
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-YyFjePHHp1LzpzYcmgqkJ0nm0gg/lJx2aZFzFy1S6eUqNjXsOqTK10zNRff2dNfssgokjkG65OlWNcIlgd3zew==
+
   /jest-pnp-resolver/1.2.2_jest-resolve@26.6.2:
-    dependencies:
-      jest-resolve: 26.6.2
-    dev: true
-    engines:
-      node: ">=6"
+    resolution:
+      {
+        integrity: sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==,
+      }
+    engines: { node: ">=6" }
     peerDependencies:
       jest-resolve: "*"
     peerDependenciesMeta:
       jest-resolve:
         optional: true
-    resolution:
-      integrity: sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==
-  /jest-regex-util/26.0.0:
+    dependencies:
+      jest-resolve: 26.6.2
     dev: true
-    engines:
-      node: ">= 10.14.2"
+
+  /jest-regex-util/26.0.0:
     resolution:
-      integrity: sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==
+      {
+        integrity: sha512-Gv3ZIs/nA48/Zvjrl34bf+oD76JHiGDUxNOVgUjh3j890sblXryjY4rss71fPtD/njchl6PSE2hIhvyWa1eT0A==,
+      }
+    engines: { node: ">= 10.14.2" }
+    dev: true
+
   /jest-resolve-dependencies/26.6.3:
+    resolution:
+      {
+        integrity: sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/types": 26.6.2
       jest-regex-util: 26.0.0
       jest-snapshot: 26.6.2
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-pVwUjJkxbhe4RY8QEWzN3vns2kqyuldKpxlxJlzEYfKSvY6/bMvxoFrYYzUO1Gx28yKWN37qyV7rIoIp2h8fTg==
+
   /jest-resolve/26.6.2:
+    resolution:
+      {
+        integrity: sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/types": 26.6.2
       chalk: 4.1.0
@@ -4799,11 +6024,13 @@ packages:
       resolve: 1.19.0
       slash: 3.0.0
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-sOxsZOq25mT1wRsfHcbtkInS+Ek7Q8jCHUB0ZUTP0tc/c41QHriU/NunqMfCUWsL4H3MHpvQD4QR9kSYhS7UvQ==
+
   /jest-runner/26.6.3:
+    resolution:
+      {
+        integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/console": 26.6.2
       "@jest/environment": 26.6.2
@@ -4825,12 +6052,21 @@ packages:
       jest-worker: 26.6.2
       source-map-support: 0.5.19
       throat: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-atgKpRHnaA2OvByG/HpGA4g6CSPS/1LK0jK3gATJAoptC1ojltpmVlYC3TYgdmGp+GLuhzpH30Gvs36szSL2JQ==
+
   /jest-runtime/26.6.3:
+    resolution:
+      {
+        integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==,
+      }
+    engines: { node: ">= 10.14.2" }
+    hasBin: true
     dependencies:
       "@jest/console": 26.6.2
       "@jest/environment": 26.6.2
@@ -4859,28 +6095,40 @@ packages:
       slash: 3.0.0
       strip-bom: 4.0.0
       yargs: 15.4.1
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    hasBin: true
-    resolution:
-      integrity: sha512-lrzyR3N8sacTAMeonbqpnSka1dHNux2uk0qqDXVkMv2c/A3wYnvQ4EXuI013Y6+gSKSCxdaczvf4HF0mVXHRdw==
+
   /jest-serializer-html/7.0.0:
+    resolution:
+      {
+        integrity: sha512-o3S2j/5yA9emV8+QRHqJ41SznW5cZ1PXIAk+aSToJffdhuaiSoDsa4IgqV8lNOHPp4cP0LNT7k5KjXjD+l6SGg==,
+      }
     dependencies:
       diffable-html: 4.0.0
     dev: true
-    resolution:
-      integrity: sha512-o3S2j/5yA9emV8+QRHqJ41SznW5cZ1PXIAk+aSToJffdhuaiSoDsa4IgqV8lNOHPp4cP0LNT7k5KjXjD+l6SGg==
+
   /jest-serializer/26.6.2:
+    resolution:
+      {
+        integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@types/node": 14.14.22
       graceful-fs: 4.2.4
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-S5wqyz0DXnNJPd/xfIzZ5Xnp1HrJWBczg8mMfMpN78OJ5eDxXyf+Ygld9wX1DnUWbIbhM1YDY95NjR4CBXkb2g==
+
   /jest-snapshot/26.6.2:
+    resolution:
+      {
+        integrity: sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@babel/types": 7.12.12
       "@jest/types": 26.6.2
@@ -4899,11 +6147,13 @@ packages:
       pretty-format: 26.6.2
       semver: 7.3.4
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-OLhxz05EzUtsAmOMzuupt1lHYXCNib0ECyuZ/PZOx9TrZcC8vL0x+DUG3TL+GLX3yHG45e6YGjIm0XwDc3q3og==
+
   /jest-util/26.6.2:
+    resolution:
+      {
+        integrity: sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/types": 26.6.2
       "@types/node": 14.14.22
@@ -4912,11 +6162,13 @@ packages:
       is-ci: 2.0.0
       micromatch: 4.0.2
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-MDW0fKfsn0OI7MS7Euz6h8HNDXVQ0gaM9uW6RjfDmd1DAFcaxX9OqIakHIqhbnmF08Cf2DLDG+ulq8YQQ0Lp0Q==
+
   /jest-validate/26.6.2:
+    resolution:
+      {
+        integrity: sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/types": 26.6.2
       camelcase: 6.2.0
@@ -4925,11 +6177,13 @@ packages:
       leven: 3.1.0
       pretty-format: 26.6.2
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-NEYZ9Aeyj0i5rQqbq+tpIOom0YS1u2MVu6+euBsvpgIme+FOfRmoC4R5p0JiAUpaFvFy24xgrpMknarR/93XjQ==
+
   /jest-watcher/26.6.2:
+    resolution:
+      {
+        integrity: sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==,
+      }
+    engines: { node: ">= 10.14.2" }
     dependencies:
       "@jest/test-result": 26.6.2
       "@jest/types": 26.6.2
@@ -4939,53 +6193,79 @@ packages:
       jest-util: 26.6.2
       string-length: 4.0.1
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    resolution:
-      integrity: sha512-WKJob0P/Em2csiVthsI68p6aGKTIcsfjH9Gsx1f0A3Italz43e3ho0geSAVsmj09RWOELP1AZ/DXyJgOgDKxXQ==
+
   /jest-worker/26.6.2:
+    resolution:
+      {
+        integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==,
+      }
+    engines: { node: ">= 10.13.0" }
     dependencies:
       "@types/node": 14.14.22
       merge-stream: 2.0.0
       supports-color: 7.2.0
     dev: true
-    engines:
-      node: ">= 10.13.0"
-    resolution:
-      integrity: sha512-KWYVV1c4i+jbMpaBC+U++4Va0cp8OisU185o73T1vo99hqi7w8tSJfUXYswwqqrjzwxa6KpRK54WhPvwf5w6PQ==
+
   /jest/26.6.3:
+    resolution:
+      {
+        integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==,
+      }
+    engines: { node: ">= 10.14.2" }
+    hasBin: true
     dependencies:
       "@jest/core": 26.6.3
       import-local: 3.0.2
       jest-cli: 26.6.3
+    transitivePeerDependencies:
+      - bufferutil
+      - canvas
+      - supports-color
+      - ts-node
+      - utf-8-validate
     dev: true
-    engines:
-      node: ">= 10.14.2"
-    hasBin: true
-    resolution:
-      integrity: sha512-lGS5PXGAzR4RF7V5+XObhqz2KZIDUA1yD0DG6pBVmy10eh0ZIXQImRuzocsI/N2XZ1GrLFwTS27In2i2jlpq1Q==
+
   /js-correct-lockfile/1.0.0:
-    dev: true
+    resolution:
+      {
+        integrity: sha512-f4nFNNgL36OYaf4psgICuVhgezkvkJucRQiiXzEDsUW+XnVBC9xO+lDOP9m3gERqs0ZeOQf5W3etdQ4HWDEW4w==,
+      }
     hasBin: true
-    resolution:
-      integrity: sha512-f4nFNNgL36OYaf4psgICuVhgezkvkJucRQiiXzEDsUW+XnVBC9xO+lDOP9m3gERqs0ZeOQf5W3etdQ4HWDEW4w==
-  /js-tokens/4.0.0:
     dev: true
+
+  /js-tokens/4.0.0:
     resolution:
-      integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==
+      {
+        integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==,
+      }
+    dev: true
+
   /js-yaml/3.14.1:
+    resolution:
+      {
+        integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==,
+      }
+    hasBin: true
     dependencies:
       argparse: 1.0.10
       esprima: 4.0.1
     dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-okMH7OXXJ7YrN9Ok3/SXrnu4iX9yOk+25nqX4imS2npuvTYDmo/QEZoqwZkYaIDk3jVvBOTOIEgEhaLOynBS9g==
+
   /jsbn/0.1.1:
+    resolution: { integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM= }
     dev: true
-    resolution:
-      integrity: sha1-peZUwuWi3rXyAdls77yoDA7y9RM=
+
   /jsdom/16.4.0:
+    resolution:
+      {
+        integrity: sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==,
+      }
+    engines: { node: ">=10" }
+    peerDependencies:
+      canvas: ^2.5.0
+    peerDependenciesMeta:
+      canvas:
+        optional: true
     dependencies:
       abab: 2.0.5
       acorn: 7.4.1
@@ -5013,184 +6293,215 @@ packages:
       whatwg-url: 8.4.0
       ws: 7.4.2
       xml-name-validator: 3.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - utf-8-validate
     dev: true
-    engines:
-      node: ">=10"
-    peerDependencies:
-      canvas: ^2.5.0
-    peerDependenciesMeta:
-      canvas:
-        optional: true
-    resolution:
-      integrity: sha512-lYMm3wYdgPhrl7pDcRmvzPhhrGVBeVhPIqeHjzeiHN3DFmD1RBpbExbi8vU7BJdH8VAZYovR8DMt0PNNDM7k8w==
+
   /jsesc/0.5.0:
-    dev: true
+    resolution: { integrity: sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0= }
     hasBin: true
-    resolution:
-      integrity: sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0=
+    dev: true
+
   /jsesc/2.5.2:
-    dev: true
-    engines:
-      node: ">=4"
+    resolution:
+      {
+        integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==,
+      }
+    engines: { node: ">=4" }
     hasBin: true
-    resolution:
-      integrity: sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==
-  /json-buffer/3.0.0:
     dev: true
-    resolution:
-      integrity: sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg=
+
+  /json-buffer/3.0.0:
+    resolution: { integrity: sha1-Wx85evx11ne96Lz8Dkfh+aPZqJg= }
+    dev: true
+
   /json-colorizer/2.2.2:
+    resolution:
+      {
+        integrity: sha512-56oZtwV1piXrQnRNTtJeqRv+B9Y/dXAYLqBBaYl/COcUdoZxgLBLAO88+CnkbT6MxNs0c5E9mPBIb2sFcNz3vw==,
+      }
     dependencies:
       chalk: 2.4.2
       lodash.get: 4.4.2
     dev: true
-    resolution:
-      integrity: sha512-56oZtwV1piXrQnRNTtJeqRv+B9Y/dXAYLqBBaYl/COcUdoZxgLBLAO88+CnkbT6MxNs0c5E9mPBIb2sFcNz3vw==
+
   /json-parse-better-errors/1.0.2:
-    dev: true
     resolution:
-      integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==
+      {
+        integrity: sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==,
+      }
+    dev: true
+
   /json-parse-even-better-errors/2.3.1:
-    dev: true
     resolution:
-      integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==
+      {
+        integrity: sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==,
+      }
+    dev: true
+
   /json-schema-traverse/0.4.1:
-    dev: true
     resolution:
-      integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==
+      {
+        integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==,
+      }
+    dev: true
+
   /json-schema-traverse/1.0.0:
-    dev: true
     resolution:
-      integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
+      {
+        integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==,
+      }
+    dev: true
+
   /json-schema/0.2.3:
+    resolution: { integrity: sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM= }
     dev: true
-    resolution:
-      integrity: sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
+
   /json-stable-stringify-without-jsonify/1.0.1:
+    resolution: { integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE= }
     dev: true
-    resolution:
-      integrity: sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=
+
   /json-stringify-safe/5.0.1:
+    resolution: { integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus= }
     dev: true
-    resolution:
-      integrity: sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=
+
   /json5/2.1.3:
+    resolution:
+      {
+        integrity: sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==,
+      }
+    engines: { node: ">=6" }
+    hasBin: true
     dependencies:
       minimist: 1.2.5
     dev: true
-    engines:
-      node: ">=6"
-    hasBin: true
-    resolution:
-      integrity: sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==
+
   /jsonfile/6.1.0:
+    resolution:
+      {
+        integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==,
+      }
     dependencies:
       universalify: 2.0.0
-    dev: true
     optionalDependencies:
       graceful-fs: 4.2.4
-    resolution:
-      integrity: sha512-5dgndWOriYSm5cnYaJNhalLNDKOqFwyDB/rr1E9ZsGciGvKPs8R2xYGCacuf3z6K1YKDz182fd+fY3cn3pMqXQ==
-  /jsonparse/1.3.1:
     dev: true
-    engines:
-      "0": node >= 0.2.0
-    resolution:
-      integrity: sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA=
+
+  /jsonparse/1.3.1:
+    resolution: { integrity: sha1-P02uSpH6wxX3EGL4UhzCOfE2YoA= }
+    engines: { "0": node >= 0.2.0 }
+    dev: true
+
   /jsprim/1.4.1:
+    resolution: { integrity: sha1-MT5mvB5cwG5Di8G3SZwuXFastqI= }
+    engines: { "0": node >=0.6.0 }
     dependencies:
       assert-plus: 1.0.0
       extsprintf: 1.3.0
       json-schema: 0.2.3
       verror: 1.10.0
     dev: true
-    engines:
-      "0": node >=0.6.0
-    resolution:
-      integrity: sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
+
   /keyv/3.1.0:
+    resolution:
+      {
+        integrity: sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==,
+      }
     dependencies:
       json-buffer: 3.0.0
     dev: true
-    resolution:
-      integrity: sha512-9ykJ/46SN/9KPM/sichzQ7OvXyGDYKGTaDlKMGCAlg2UK8KRy4jb0d8sFc+0Tt0YYnThq8X2RZgCg74RPxgcVA==
+
   /kind-of/3.2.2:
+    resolution: { integrity: sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-buffer: 1.1.6
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=
+
   /kind-of/4.0.0:
+    resolution: { integrity: sha1-IIE989cSkosgc3hpGkUGb65y3Vc= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-buffer: 1.1.6
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-IIE989cSkosgc3hpGkUGb65y3Vc=
+
   /kind-of/5.1.0:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==
+      {
+        integrity: sha512-NGEErnH6F2vUuXDh+OlbcKW7/wOcfdRHaZ7VWtqCztfHri/++YKmP51OdWeGPuqCOba6kk2OTe5d02VmTB80Pw==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /kind-of/6.0.3:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==
+      {
+        integrity: sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /kleur/3.0.3:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==
+      {
+        integrity: sha512-eTIzlVOSUR+JxdDFepEYcBMtZ9Qqdef+rnzWdRZuMbOywu5tO2w2N7rqjoANZ5k9vywhL6Br1VRjUIgTQx4E8w==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /latest-version/5.1.0:
+    resolution:
+      {
+        integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       package-json: 6.5.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-weT+r0kTkRQdCdYCNtkMwWXQTMEswKrFBkm4ckQOMVhhqhIMI1UT2hMj+1iigIhgSZm5gTmrRXBNoGUgaTY1xA==
+
   /lazy-ass/1.6.0:
+    resolution: { integrity: sha1-eZllXoZGwX8In90YfRUNMyTVRRM= }
+    engines: { node: "> 0.8" }
     dev: true
-    engines:
-      node: "> 0.8"
-    resolution:
-      integrity: sha1-eZllXoZGwX8In90YfRUNMyTVRRM=
+
   /leven/3.1.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==
+      {
+        integrity: sha512-qsda+H8jTaUaN/x5vzW2rzc+8Rw4TAQ/4KjB46IwK5VH+IlVeeeje/EoZRpiXvIqjFgK84QffqPztGI3VBLG1A==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /levn/0.3.0:
+    resolution: { integrity: sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4= }
+    engines: { node: ">= 0.8.0" }
     dependencies:
       prelude-ls: 1.1.2
       type-check: 0.3.2
     dev: true
-    engines:
-      node: ">= 0.8.0"
-    resolution:
-      integrity: sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=
+
   /levn/0.4.1:
+    resolution:
+      {
+        integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==,
+      }
+    engines: { node: ">= 0.8.0" }
     dependencies:
       prelude-ls: 1.2.1
       type-check: 0.4.0
     dev: true
-    engines:
-      node: ">= 0.8.0"
-    resolution:
-      integrity: sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ==
+
   /lines-and-columns/1.1.6:
+    resolution: { integrity: sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA= }
     dev: true
-    resolution:
-      integrity: sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
+
   /list-exports/1.0.4:
+    resolution:
+      {
+        integrity: sha512-a7RUpTRKwI3CMx2h/11uW3X44oyEVBuQTPfp2UBxtfwMSWoJ9zPpKwZNFez/JwRRsL95OL1G8emxu12HAo1vzw==,
+      }
+    engines: { node: ">= 10" }
     dependencies:
       array.prototype.flatmap: 1.2.4
       get-package-type: 0.1.0
@@ -5200,17 +6511,20 @@ packages:
       read-package-json: 3.0.0
       resolve: 2.0.0-next.2
     dev: true
-    engines:
-      node: ">= 10"
-    resolution:
-      integrity: sha512-a7RUpTRKwI3CMx2h/11uW3X44oyEVBuQTPfp2UBxtfwMSWoJ9zPpKwZNFez/JwRRsL95OL1G8emxu12HAo1vzw==
+
   /listr-silent-renderer/1.1.1:
+    resolution: { integrity: sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-kktaN1cVN3C/Go4/v3S4u/P5JC4=
+
   /listr-update-renderer/0.5.0_listr@0.14.3:
+    resolution:
+      {
+        integrity: sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==,
+      }
+    engines: { node: ">=6" }
+    peerDependencies:
+      listr: ^0.14.2
     dependencies:
       chalk: 1.1.3
       cli-truncate: 0.2.1
@@ -5222,24 +6536,26 @@ packages:
       log-update: 2.3.0
       strip-ansi: 3.0.1
     dev: true
-    engines:
-      node: ">=6"
-    peerDependencies:
-      listr: ^0.14.2
-    resolution:
-      integrity: sha512-tKRsZpKz8GSGqoI/+caPmfrypiaq+OQCbd+CovEC24uk1h952lVj5sC7SqyFUm+OaJ5HN/a1YLt5cit2FMNsFA==
+
   /listr-verbose-renderer/0.5.0:
+    resolution:
+      {
+        integrity: sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==,
+      }
+    engines: { node: ">=4" }
     dependencies:
       chalk: 2.4.2
       cli-cursor: 2.1.0
       date-fns: 1.30.1
       figures: 2.0.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha512-04PDPqSlsqIOaaaGZ+41vq5FejI9auqTInicFRndCBgE3bXG8D6W1I+mWhk+1nqbHmyhla/6BUrd5OSiHwKRXw==
+
   /listr/0.14.3:
+    resolution:
+      {
+        integrity: sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       "@samverschueren/stream-to-observable": 0.3.1_rxjs@6.6.3
       is-observable: 1.1.0
@@ -5250,99 +6566,119 @@ packages:
       listr-verbose-renderer: 0.5.0
       p-map: 2.1.0
       rxjs: 6.6.3
+    transitivePeerDependencies:
+      - zen-observable
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-RmAl7su35BFd/xoMamRjpIE4j3v+L28o8CT5YhAXQJm1fD+1l9ngXY8JAQRJ+tFK2i5njvi0iRUKV09vPwA0iA==
+
   /locate-path/3.0.0:
+    resolution:
+      {
+        integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       p-locate: 3.0.0
       path-exists: 3.0.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-7AO748wWnIhNqAuaty2ZWHkQHRSNfPVIsPIfwEOWO22AmaoVrWavlOcMR5nzTLNYvp36X220/maaRsrec1G65A==
+
   /locate-path/5.0.0:
+    resolution:
+      {
+        integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       p-locate: 4.1.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==
+
   /locate-path/6.0.0:
+    resolution:
+      {
+        integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       p-locate: 5.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw==
+
   /lodash.get/4.4.2:
+    resolution: { integrity: sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk= }
     dev: true
-    resolution:
-      integrity: sha1-LRd/ZS+jHpObRDjVNBSZ36OCXpk=
+
   /lodash.once/4.1.1:
+    resolution: { integrity: sha1-DdOXEhPHxW34gJd9UEyI+0cal6w= }
     dev: true
-    resolution:
-      integrity: sha1-DdOXEhPHxW34gJd9UEyI+0cal6w=
+
   /lodash.sortby/4.7.0:
+    resolution: { integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg= }
     dev: true
-    resolution:
-      integrity: sha1-7dFMgk4sycHgsKG0K7UhBRakJDg=
+
   /lodash/4.17.20:
-    dev: true
     resolution:
-      integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==
+      {
+        integrity: sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA==,
+      }
+    dev: true
+
   /log-symbols/1.0.2:
+    resolution: { integrity: sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       chalk: 1.1.3
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-N2/3tY6jCGoPCfrMdGF+ylAeGhg=
+
   /log-symbols/4.0.0:
+    resolution:
+      {
+        integrity: sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       chalk: 4.1.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-FN8JBzLx6CzeMrB0tg6pqlGU1wCrXW+ZXGH481kfsBqer0hToTIiHdjH4Mq8xJUbvATujKCvaREGWpGUionraA==
+
   /log-update/2.3.0:
+    resolution: { integrity: sha1-iDKP19HOeTiykoN0bwsbwSayRwg= }
+    engines: { node: ">=4" }
     dependencies:
       ansi-escapes: 3.2.0
       cli-cursor: 2.1.0
       wrap-ansi: 3.0.1
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-iDKP19HOeTiykoN0bwsbwSayRwg=
+
   /lowercase-keys/1.0.1:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==
+      {
+        integrity: sha512-G2Lj61tXDnVFFOi8VZds+SoQjtQC3dgokKdDG2mTm1tx4m50NUHBOZSBwQQHyy0V12A0JTG4icfZQH+xPyh8VA==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /lowercase-keys/2.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==
+      {
+        integrity: sha512-tqNXrS78oMOE73NMxK4EMLQsQowWf8jKooH9g7xPavRT706R6bkQJ6DY2Te7QukaZsulxa30wQ7bk0pm4XiHmA==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /lru-cache/6.0.0:
+    resolution:
+      {
+        integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       yallist: 4.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==
+
   /ls-exports/1.1.0:
+    resolution:
+      {
+        integrity: sha512-plVAIT/VDNlp9WGaaZvld2tTOEkzk03Xvuq5rIrLrYB133ZxtNPJfB9hpgvasPzTP8pTfueaYWMXyGywRAr0Dw==,
+      }
+    engines: { node: ">= 12 || ^10.17" }
+    hasBin: true
     dependencies:
       chalk: 4.1.0
       json-colorizer: 2.2.2
@@ -5356,32 +6692,40 @@ packages:
       tmp: 0.2.1
       tree-walk: 0.4.0
       yargs: 16.2.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">= 12 || ^10.17"
-    hasBin: true
-    resolution:
-      integrity: sha512-plVAIT/VDNlp9WGaaZvld2tTOEkzk03Xvuq5rIrLrYB133ZxtNPJfB9hpgvasPzTP8pTfueaYWMXyGywRAr0Dw==
+
   /lz-string/1.4.4:
-    dev: true
+    resolution: { integrity: sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY= }
     hasBin: true
-    resolution:
-      integrity: sha1-wNjq82BZ9wV5bh40SBHPTEmNOiY=
+    dev: true
+
   /magic-string/0.25.7:
+    resolution:
+      {
+        integrity: sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==,
+      }
     dependencies:
       sourcemap-codec: 1.4.8
     dev: true
-    resolution:
-      integrity: sha512-4CrMT5DOHTDk4HYDlzmwu4FVCcIYI8gauveasrdCu2IKIFOJ3f0v/8MDGJCDL9oD2ppz/Av1b0Nj345H9M+XIA==
+
   /make-dir/3.1.0:
+    resolution:
+      {
+        integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       semver: 6.3.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==
+
   /make-fetch-happen/8.0.13:
+    resolution:
+      {
+        integrity: sha512-rQ5NijwwdU8tIaBrpTtSVrNCcAJfyDRcKBC76vOQlyJX588/88+TE+UpjWl4BgG7gCkp29wER7xcRqkeg+x64Q==,
+      }
+    engines: { node: ">= 10" }
     dependencies:
       agentkeepalive: 4.1.3
       cacache: 15.0.5
@@ -5398,44 +6742,47 @@ packages:
       promise-retry: 1.1.1
       socks-proxy-agent: 5.0.0
       ssri: 8.0.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">= 10"
-    resolution:
-      integrity: sha512-rQ5NijwwdU8tIaBrpTtSVrNCcAJfyDRcKBC76vOQlyJX588/88+TE+UpjWl4BgG7gCkp29wER7xcRqkeg+x64Q==
+
   /makeerror/1.0.11:
+    resolution: { integrity: sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw= }
     dependencies:
       tmpl: 1.0.4
     dev: true
-    resolution:
-      integrity: sha1-4BpckQnyr3lmDk6LlYd5AYT1qWw=
+
   /map-cache/0.2.2:
+    resolution: { integrity: sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
+
   /map-obj/1.0.1:
+    resolution: { integrity: sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-2TPOuSBdgr3PSIb2dCvcK03qFG0=
+
   /map-obj/4.1.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==
+      {
+        integrity: sha512-glc9y00wgtwcDmp7GaE/0b0OnxpNJsVf3ael/An6Fe2Q51LLwN1er6sdomLRzz5h0+yMpiYLhWYF5R7HeqVd4g==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /map-visit/1.0.0:
+    resolution: { integrity: sha1-7Nyo8TFE5mDxtb1B8S80edmN+48= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       object-visit: 1.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
+
   /meow/7.1.1:
+    resolution:
+      {
+        integrity: sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       "@types/minimist": 1.2.1
       camelcase-keys: 6.2.2
@@ -5449,20 +6796,27 @@ packages:
       type-fest: 0.13.1
       yargs-parser: 18.1.3
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-GWHvA5QOcS412WCo8vwKDlTelGLsCGBVevQB5Kva961rmNfun0PCbv5+xta2kUMFJyR8/oWnn7ddeKdosbAPbA==
+
   /merge-stream/2.0.0:
+    resolution:
+      {
+        integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==,
+      }
     dev: true
-    resolution:
-      integrity: sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w==
+
   /merge2/1.4.1:
-    engines:
-      node: ">= 8"
     resolution:
-      integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==
+      {
+        integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==,
+      }
+    engines: { node: ">= 8" }
+
   /micromatch/3.1.10:
+    resolution:
+      {
+        integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
@@ -5478,191 +6832,250 @@ packages:
       snapdragon: 0.8.2
       to-regex: 3.0.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-MWikgl9n9M3w+bpsY3He8L+w9eF9338xRl8IAO5viDizwSzziFEyUzo2xrrloB64ADbTf8uA8vRqqttDTOmccg==
+
   /micromatch/4.0.2:
+    resolution:
+      {
+        integrity: sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       braces: 3.0.2
       picomatch: 2.2.2
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==
+
   /mime-db/1.45.0:
-    dev: true
-    engines:
-      node: ">= 0.6"
     resolution:
-      integrity: sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==
+      {
+        integrity: sha512-CkqLUxUk15hofLoLyljJSrukZi8mAtgd+yE5uO4tqRZsdsAJKv0O+rFMhVDRJgozy+yG6md5KwuXhD4ocIoP+w==,
+      }
+    engines: { node: ">= 0.6" }
+    dev: true
+
   /mime-types/2.1.28:
+    resolution:
+      {
+        integrity: sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==,
+      }
+    engines: { node: ">= 0.6" }
     dependencies:
       mime-db: 1.45.0
     dev: true
-    engines:
-      node: ">= 0.6"
-    resolution:
-      integrity: sha512-0TO2yJ5YHYr7M2zzT7gDU1tbwHxEUWBCLt0lscSNpcdAfFyJOVEpRYNS7EXVcTLNj/25QO8gulHC5JtTzSE2UQ==
+
   /mimic-fn/1.2.0:
-    dev: true
-    engines:
-      node: ">=4"
     resolution:
-      integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==
+      {
+        integrity: sha512-jf84uxzwiuiIVKiOLpfYk7N46TSy8ubTonmneY9vrpHNAnp0QBt2BxWV9dO3/j+BoVAb+a5G6YDPW3M5HOdMWQ==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /mimic-fn/2.1.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==
+      {
+        integrity: sha512-OqbOk5oEQeAZ8WXWydlu9HJjz9WVdEIvamMCcXmuqUYjTknH/sqsWvhQ3vgwKFRR1HpjvNBKQ37nbJgYzGqGcg==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /mimic-response/1.0.1:
-    dev: true
-    engines:
-      node: ">=4"
     resolution:
-      integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
+      {
+        integrity: sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /min-indent/1.0.1:
-    dev: true
-    engines:
-      node: ">=4"
     resolution:
-      integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==
+      {
+        integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /minimatch/3.0.4:
+    resolution:
+      {
+        integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==,
+      }
     dependencies:
       brace-expansion: 1.1.11
     dev: true
-    resolution:
-      integrity: sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
+
   /minimist-options/4.1.0:
+    resolution:
+      {
+        integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==,
+      }
+    engines: { node: ">= 6" }
     dependencies:
       arrify: 1.0.1
       is-plain-obj: 1.1.0
       kind-of: 6.0.3
     dev: true
-    engines:
-      node: ">= 6"
-    resolution:
-      integrity: sha512-Q4r8ghd80yhO/0j1O3B2BjweX3fiHg9cdOwjJd2J76Q135c+NDxGCqdYKQ1SKBuFfgWbAUzBfvYjPUEeNgqN1A==
+
   /minimist/1.2.5:
-    dev: true
     resolution:
-      integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==
+      {
+        integrity: sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==,
+      }
+    dev: true
+
   /minipass-collect/1.0.2:
+    resolution:
+      {
+        integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==,
+      }
+    engines: { node: ">= 8" }
     dependencies:
       minipass: 3.1.3
     dev: true
-    engines:
-      node: ">= 8"
-    resolution:
-      integrity: sha512-6T6lH0H8OG9kITm/Jm6tdooIbogG9e0tLgpY6mphXSm/A9u8Nq1ryBG+Qspiub9LjWlBPsPS3tWQ/Botq4FdxA==
+
   /minipass-fetch/1.3.3:
+    resolution:
+      {
+        integrity: sha512-akCrLDWfbdAWkMLBxJEeWTdNsjML+dt5YgOI4gJ53vuO0vrmYQkUPxa6j6V65s9CcePIr2SSWqjT2EcrNseryQ==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       minipass: 3.1.3
       minipass-sized: 1.0.3
       minizlib: 2.1.2
-    dev: true
-    engines:
-      node: ">=8"
     optionalDependencies:
       encoding: 0.1.13
-    resolution:
-      integrity: sha512-akCrLDWfbdAWkMLBxJEeWTdNsjML+dt5YgOI4gJ53vuO0vrmYQkUPxa6j6V65s9CcePIr2SSWqjT2EcrNseryQ==
+    dev: true
+
   /minipass-flush/1.0.5:
+    resolution:
+      {
+        integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==,
+      }
+    engines: { node: ">= 8" }
     dependencies:
       minipass: 3.1.3
     dev: true
-    engines:
-      node: ">= 8"
-    resolution:
-      integrity: sha512-JmQSYYpPUqX5Jyn1mXaRwOda1uQ8HP5KAT/oDSLCzt1BYRhQU0/hDtsB1ufZfEEzMZ9aAVmsBw8+FWsIXlClWw==
+
   /minipass-json-stream/1.0.1:
+    resolution:
+      {
+        integrity: sha512-ODqY18UZt/I8k+b7rl2AENgbWE8IDYam+undIJONvigAz8KR5GWblsFTEfQs0WODsjbSXWlm+JHEv8Gr6Tfdbg==,
+      }
     dependencies:
       jsonparse: 1.3.1
       minipass: 3.1.3
     dev: true
-    resolution:
-      integrity: sha512-ODqY18UZt/I8k+b7rl2AENgbWE8IDYam+undIJONvigAz8KR5GWblsFTEfQs0WODsjbSXWlm+JHEv8Gr6Tfdbg==
+
   /minipass-pipeline/1.2.4:
+    resolution:
+      {
+        integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       minipass: 3.1.3
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-xuIq7cIOt09RPRJ19gdi4b+RiNvDFYe5JH+ggNvBqGqpQXcru3PcRmOZuHBKWK1Txf9+cQ+HMVN4d6z46LZP7A==
+
   /minipass-sized/1.0.3:
+    resolution:
+      {
+        integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       minipass: 3.1.3
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-MbkQQ2CTiBMlA2Dm/5cY+9SWFEN8pzzOXi6rlM5Xxq0Yqbda5ZQy9sU75a673FE9ZK0Zsbr6Y5iP6u9nktfg2g==
+
   /minipass/3.1.3:
+    resolution:
+      {
+        integrity: sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       yallist: 4.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==
+
   /minizlib/2.1.2:
+    resolution:
+      {
+        integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==,
+      }
+    engines: { node: ">= 8" }
     dependencies:
       minipass: 3.1.3
       yallist: 4.0.0
     dev: true
-    engines:
-      node: ">= 8"
-    resolution:
-      integrity: sha512-bAxsR8BVfj60DWXHE3u30oHzfl4G7khkSuPW+qvpd7jFRHm7dLxOjUk1EHACJ/hxLY8phGJ0YhYHZo7jil7Qdg==
+
   /mixin-deep/1.3.2:
+    resolution:
+      {
+        integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       for-in: 1.0.2
       is-extendable: 1.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-WRoDn//mXBiJ1H40rqa3vH0toePwSsGb45iInWlTySa+Uu4k3tYUSxa2v1KqAiLtvlrSzaExqS1gtk96A9zvEA==
+
   /mkdirp/0.5.5:
+    resolution:
+      {
+        integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==,
+      }
+    hasBin: true
     dependencies:
       minimist: 1.2.5
     dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==
+
   /mkdirp/1.0.4:
-    dev: true
-    engines:
-      node: ">=10"
+    resolution:
+      {
+        integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==,
+      }
+    engines: { node: ">=10" }
     hasBin: true
-    resolution:
-      integrity: sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
+    dev: true
+
   /moment/2.29.1:
-    dev: true
     resolution:
-      integrity: sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
+      {
+        integrity: sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==,
+      }
+    dev: true
+
   /mri/1.1.6:
-    dev: true
-    engines:
-      node: ">=4"
     resolution:
-      integrity: sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==
+      {
+        integrity: sha512-oi1b3MfbyGa7FJMP9GmLTttni5JoICpYBRlq+x5V16fZbLsnL9N3wFqqIm/nIG43FjUFkFh9Epzp/kzUGUnJxQ==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /ms/2.0.0:
+    resolution: { integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g= }
     dev: true
-    resolution:
-      integrity: sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=
+
   /ms/2.1.2:
-    dev: true
     resolution:
-      integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==
+      {
+        integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==,
+      }
+    dev: true
+
   /ms/2.1.3:
-    dev: true
     resolution:
-      integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==
+      {
+        integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==,
+      }
+    dev: true
+
   /multimatch/4.0.0:
+    resolution:
+      {
+        integrity: sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       "@types/minimatch": 3.0.3
       array-differ: 3.0.0
@@ -5670,11 +7083,13 @@ packages:
       arrify: 2.0.1
       minimatch: 3.0.4
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-lDmx79y1z6i7RNx0ZGCPq1bzJ6ZoDDKbvh7jxr9SJcWLkShMzXrHbYVpTdnhNM5MXpDUxCQ4DgqVttVXlBgiBQ==
+
   /nanomatch/1.2.13:
+    resolution:
+      {
+        integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       arr-diff: 4.0.0
       array-unique: 0.3.2
@@ -5688,19 +7103,25 @@ packages:
       snapdragon: 0.8.2
       to-regex: 3.0.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-fpoe2T0RbHwBTBUOftAfBPaDEi06ufaUai0mE6Yn1kacc3SnTErfb/h+X94VXzI64rKFHYImXSvdwGGCmwOqCA==
+
   /natural-compare/1.4.0:
+    resolution: { integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc= }
     dev: true
-    resolution:
-      integrity: sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
   /nice-try/1.0.5:
-    dev: true
     resolution:
-      integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
+      {
+        integrity: sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==,
+      }
+    dev: true
+
   /node-gyp/7.1.2:
+    resolution:
+      {
+        integrity: sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==,
+      }
+    engines: { node: ">= 10.12.0" }
+    hasBin: true
     dependencies:
       env-paths: 2.2.0
       glob: 7.1.6
@@ -5713,22 +7134,21 @@ packages:
       tar: 6.1.0
       which: 2.0.2
     dev: true
-    engines:
-      node: ">= 10.12.0"
-    hasBin: true
-    resolution:
-      integrity: sha512-CbpcIo7C3eMu3dL1c3d0xw449fHIGALIJsRP4DDPHpyiW8vcriNY7ubh9TE4zEKfSxscY7PjeFnshE7h75ynjQ==
+
   /node-int64/0.4.0:
+    resolution: { integrity: sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs= }
     dev: true
-    resolution:
-      integrity: sha1-h6kGXNs1XTGC2PlM4RGIuCXGijs=
+
   /node-modules-regexp/1.0.0:
+    resolution: { integrity: sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-jZ2+KJZKSsVxLpExZCEHxx6Q7EA=
+
   /node-notifier/8.0.1:
+    resolution:
+      {
+        integrity: sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==,
+      }
     dependencies:
       growly: 1.3.0
       is-wsl: 2.2.0
@@ -5738,110 +7158,142 @@ packages:
       which: 2.0.2
     dev: true
     optional: true
-    resolution:
-      integrity: sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==
+
   /node-releases/1.1.70:
-    dev: true
     resolution:
-      integrity: sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==
+      {
+        integrity: sha512-Slf2s69+2/uAD79pVVQo8uSiC34+g8GWY8UH2Qtqv34ZfhYrxpYpfzs9Js9d6O0mbDmALuxaTlplnBTnSELcrw==,
+      }
+    dev: true
+
   /nopt/5.0.0:
+    resolution:
+      {
+        integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==,
+      }
+    engines: { node: ">=6" }
+    hasBin: true
     dependencies:
       abbrev: 1.1.1
     dev: true
-    engines:
-      node: ">=6"
-    hasBin: true
-    resolution:
-      integrity: sha512-Tbj67rffqceeLpcRXrT7vKAN8CwfPeIBgM7E6iBkmKLV7bEMwpGgYLGv0jACUsECaa/vuxP0IjEont6umdMgtQ==
+
   /normalize-package-data/2.5.0:
+    resolution:
+      {
+        integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==,
+      }
     dependencies:
       hosted-git-info: 2.8.8
       resolve: 1.19.0
       semver: 5.7.1
       validate-npm-package-license: 3.0.4
     dev: true
-    resolution:
-      integrity: sha512-/5CMN3T0R4XTj4DcGaexo+roZSdSFW/0AOOTROrjxzCG1wrWXEsGbRKevjlIL+ZDE4sZlJr5ED4YW0yqmkK+eA==
+
   /normalize-package-data/3.0.0:
+    resolution:
+      {
+        integrity: sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       hosted-git-info: 3.0.7
       resolve: 1.19.0
       semver: 7.3.4
       validate-npm-package-license: 3.0.4
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-6lUjEI0d3v6kFrtgA/lOx4zHCWULXsFNIjHolnZCKCTLA6m/G625cdn3O7eNmT0iD3jfo6HZ9cdImGZwf21prw==
+
   /normalize-path/2.1.1:
+    resolution: { integrity: sha1-GrKLVW4Zg2Oowab35vogE3/mrtk= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       remove-trailing-separator: 1.1.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=
+
   /normalize-path/3.0.0:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==
+      {
+        integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /normalize-url/4.5.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==
+      {
+        integrity: sha512-2s47yzUxdexf1OhyRi4Em83iQk0aPvwTddtFz4hnSSw9dCEsLEGf6SwIO8ss/19S9iBb5sJaOuTvTGDeZI00BQ==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /npm-bundled/1.1.1:
+    resolution:
+      {
+        integrity: sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==,
+      }
     dependencies:
       npm-normalize-package-bin: 1.0.1
     dev: true
-    resolution:
-      integrity: sha512-gqkfgGePhTpAEgUsGEgcq1rqPXA+tv/aVBlgEzfXwA1yiUJF7xtEt3CtVwOjNYQOVknDk0F20w58Fnm3EtG0fA==
+
   /npm-install-checks/4.0.0:
+    resolution:
+      {
+        integrity: sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       semver: 7.3.4
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-09OmyDkNLYwqKPOnbI8exiOZU2GVVmQp7tgez2BPi5OZC8M82elDAps7sxC4l//uSUtotWqoEIDwjRvWH4qz8w==
+
   /npm-normalize-package-bin/1.0.1:
-    dev: true
     resolution:
-      integrity: sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==
+      {
+        integrity: sha512-EPfafl6JL5/rU+ot6P3gRSCpPDW5VmIzX959Ob1+ySFUuuYHWHekXpwdUZcKP5C+DS4GEtdJluwBjnsNDl+fSA==,
+      }
+    dev: true
+
   /npm-package-arg/8.1.0:
+    resolution:
+      {
+        integrity: sha512-/ep6QDxBkm9HvOhOg0heitSd7JHA1U7y1qhhlRlteYYAi9Pdb/ZV7FW5aHpkrpM8+P+4p/jjR8zCyKPBMBjSig==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       hosted-git-info: 3.0.7
       semver: 7.3.4
       validate-npm-package-name: 3.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-/ep6QDxBkm9HvOhOg0heitSd7JHA1U7y1qhhlRlteYYAi9Pdb/ZV7FW5aHpkrpM8+P+4p/jjR8zCyKPBMBjSig==
+
   /npm-packlist/2.1.4:
+    resolution:
+      {
+        integrity: sha512-Qzg2pvXC9U4I4fLnUrBmcIT4x0woLtUgxUi9eC+Zrcv1Xx5eamytGAfbDWQ67j7xOcQ2VW1I3su9smVTIdu7Hw==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
     dependencies:
       glob: 7.1.6
       ignore-walk: 3.0.3
       npm-bundled: 1.1.1
       npm-normalize-package-bin: 1.0.1
     dev: true
-    engines:
-      node: ">=10"
-    hasBin: true
-    resolution:
-      integrity: sha512-Qzg2pvXC9U4I4fLnUrBmcIT4x0woLtUgxUi9eC+Zrcv1Xx5eamytGAfbDWQ67j7xOcQ2VW1I3su9smVTIdu7Hw==
+
   /npm-pick-manifest/6.1.0:
+    resolution:
+      {
+        integrity: sha512-ygs4k6f54ZxJXrzT0x34NybRlLeZ4+6nECAIbr2i0foTnijtS1TJiyzpqtuUAJOps/hO0tNDr8fRV5g+BtRlTw==,
+      }
     dependencies:
       npm-install-checks: 4.0.0
       npm-package-arg: 8.1.0
       semver: 7.3.4
     dev: true
-    resolution:
-      integrity: sha512-ygs4k6f54ZxJXrzT0x34NybRlLeZ4+6nECAIbr2i0foTnijtS1TJiyzpqtuUAJOps/hO0tNDr8fRV5g+BtRlTw==
+
   /npm-registry-fetch/9.0.0:
+    resolution:
+      {
+        integrity: sha512-PuFYYtnQ8IyVl6ib9d3PepeehcUeHN9IO5N/iCRhyg9tStQcqGQBRVHmfmMWPDERU3KwZoHFvbJ4FPXPspvzbA==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       "@npmcli/ci-detect": 1.3.0
       lru-cache: 6.0.0
@@ -5851,170 +7303,195 @@ packages:
       minipass-json-stream: 1.0.1
       minizlib: 2.1.2
       npm-package-arg: 8.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-PuFYYtnQ8IyVl6ib9d3PepeehcUeHN9IO5N/iCRhyg9tStQcqGQBRVHmfmMWPDERU3KwZoHFvbJ4FPXPspvzbA==
+
   /npm-run-path/2.0.2:
+    resolution: { integrity: sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8= }
+    engines: { node: ">=4" }
     dependencies:
       path-key: 2.0.1
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=
+
   /npm-run-path/4.0.1:
+    resolution:
+      {
+        integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       path-key: 3.1.1
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw==
+
   /npmlog/4.1.2:
+    resolution:
+      {
+        integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==,
+      }
     dependencies:
       are-we-there-yet: 1.1.5
       console-control-strings: 1.1.0
       gauge: 2.7.4
       set-blocking: 2.0.0
     dev: true
-    resolution:
-      integrity: sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==
+
   /number-is-nan/1.0.1:
+    resolution: { integrity: sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=
+
   /nwsapi/2.2.0:
-    dev: true
     resolution:
-      integrity: sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==
+      {
+        integrity: sha512-h2AatdwYH+JHiZpv7pt/gSX1XoRGb7L/qSIeuqA6GwYoF9w1vP1cw42TO0aI2pNyshRK5893hNSl+1//vHK7hQ==,
+      }
+    dev: true
+
   /oauth-sign/0.9.0:
-    dev: true
     resolution:
-      integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==
+      {
+        integrity: sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==,
+      }
+    dev: true
+
   /object-assign/4.1.1:
+    resolution: { integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=
+
   /object-copy/0.1.0:
+    resolution: { integrity: sha1-fn2Fi3gb18mRpBupde04EnVOmYw= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       copy-descriptor: 0.1.1
       define-property: 0.2.5
       kind-of: 3.2.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-fn2Fi3gb18mRpBupde04EnVOmYw=
+
   /object-inspect/1.9.0:
-    dev: true
     resolution:
-      integrity: sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==
+      {
+        integrity: sha512-i3Bp9iTqwhaLZBxGkRfo5ZbE07BQRT7MGu8+nNgwW9ItGp1TzCTw2DLEoWwjClxBjOFI/hWljTAmYGCEwmtnOw==,
+      }
+    dev: true
+
   /object-keys/1.1.1:
-    dev: true
-    engines:
-      node: ">= 0.4"
     resolution:
-      integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==
+      {
+        integrity: sha512-NuAESUOUMrlIXOfHKzD6bpPu3tYt3xvjNdRIQ+FeT0lNb4K8WR70CaDxhuNguS2XG+GjkyMwOzsN5ZktImfhLA==,
+      }
+    engines: { node: ">= 0.4" }
+    dev: true
+
   /object-visit/1.0.1:
+    resolution: { integrity: sha1-95xEk68MU3e1n+OdOV5BBC3QRbs= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       isobject: 3.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=
+
   /object.assign/4.1.2:
+    resolution:
+      {
+        integrity: sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==,
+      }
+    engines: { node: ">= 0.4" }
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
       has-symbols: 1.0.1
       object-keys: 1.1.1
     dev: true
-    engines:
-      node: ">= 0.4"
-    resolution:
-      integrity: sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
+
   /object.entries/1.1.3:
+    resolution:
+      {
+        integrity: sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==,
+      }
+    engines: { node: ">= 0.4" }
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
       es-abstract: 1.18.0-next.2
       has: 1.0.3
     dev: true
-    engines:
-      node: ">= 0.4"
-    resolution:
-      integrity: sha512-ym7h7OZebNS96hn5IJeyUmaWhaSM4SVtAPPfNLQEI2MYWCO2egsITb9nab2+i/Pwibx+R0mtn+ltKJXRSeTMGg==
+
   /object.fromentries/2.0.3:
+    resolution:
+      {
+        integrity: sha512-IDUSMXs6LOSJBWE++L0lzIbSqHl9KDCfff2x/JSEIDtEUavUnyMYC2ZGay/04Zq4UT8lvd4xNhU4/YHKibAOlw==,
+      }
+    engines: { node: ">= 0.4" }
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
       es-abstract: 1.18.0-next.2
       has: 1.0.3
     dev: true
-    engines:
-      node: ">= 0.4"
-    resolution:
-      integrity: sha512-IDUSMXs6LOSJBWE++L0lzIbSqHl9KDCfff2x/JSEIDtEUavUnyMYC2ZGay/04Zq4UT8lvd4xNhU4/YHKibAOlw==
+
   /object.pick/1.3.0:
+    resolution: { integrity: sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       isobject: 3.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=
+
   /object.values/1.1.2:
+    resolution:
+      {
+        integrity: sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==,
+      }
+    engines: { node: ">= 0.4" }
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
       es-abstract: 1.18.0-next.2
       has: 1.0.3
     dev: true
-    engines:
-      node: ">= 0.4"
-    resolution:
-      integrity: sha512-MYC0jvJopr8EK6dPBiO8Nb9mvjdypOachO5REGk6MXzujbBrAisKo3HmdEI6kZDL6fC31Mwee/5YbtMebixeag==
+
   /once/1.4.0:
+    resolution: { integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E= }
     dependencies:
       wrappy: 1.0.2
     dev: true
-    resolution:
-      integrity: sha1-WDsap3WWHUsROsF9nFC6753Xa9E=
+
   /onetime/1.1.0:
+    resolution: { integrity: sha1-ofeDj4MUxRbwXs78vEzP4EtO14k= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-ofeDj4MUxRbwXs78vEzP4EtO14k=
+
   /onetime/2.0.1:
+    resolution: { integrity: sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ= }
+    engines: { node: ">=4" }
     dependencies:
       mimic-fn: 1.2.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=
+
   /onetime/5.1.2:
+    resolution:
+      {
+        integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       mimic-fn: 2.1.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg==
+
   /opencollective-postinstall/2.0.3:
-    dev: true
-    hasBin: true
     resolution:
-      integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==
+      {
+        integrity: sha512-8AV/sCtuzUeTo8gQK5qDZzARrulB3egtLzFgteqB2tcT4Mw7B8Kt7JcDHmltjz6FOAHsvTevk70gZEbhM4ZS9Q==,
+      }
+    hasBin: true
+    dev: true
+
   /optionator/0.8.3:
+    resolution:
+      {
+        integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==,
+      }
+    engines: { node: ">= 0.8.0" }
     dependencies:
       deep-is: 0.1.3
       fast-levenshtein: 2.0.6
@@ -6023,11 +7500,13 @@ packages:
       type-check: 0.3.2
       word-wrap: 1.2.3
     dev: true
-    engines:
-      node: ">= 0.8.0"
-    resolution:
-      integrity: sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==
+
   /optionator/0.9.1:
+    resolution:
+      {
+        integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==,
+      }
+    engines: { node: ">= 0.8.0" }
     dependencies:
       deep-is: 0.1.3
       fast-levenshtein: 2.0.6
@@ -6036,104 +7515,128 @@ packages:
       type-check: 0.4.0
       word-wrap: 1.2.3
     dev: true
-    engines:
-      node: ">= 0.8.0"
-    resolution:
-      integrity: sha512-74RlY5FCnhq4jRxVUPKDaRwrVNXMqsGsiW6AJw4XK8hmtm10wC0ypZBLw5IIp85NZMr91+qd1RvvENwg7jjRFw==
+
   /ospath/1.2.2:
+    resolution: { integrity: sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs= }
     dev: true
-    resolution:
-      integrity: sha1-EnZjl3Sj+O8lcvf+QoDg6kVQwHs=
+
   /p-cancelable/1.1.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==
+      {
+        integrity: sha512-s73XxOZ4zpt1edZYZzvhqFa6uvQc1vwUa0K0BdtIZgQMAJj9IbebH+JkgKZc9h+B05PKHLOTl4ajG1BmNrVZlw==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /p-each-series/2.2.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==
+      {
+        integrity: sha512-ycIL2+1V32th+8scbpTvyHNaHe02z0sjgh91XXjAk+ZeXoPN4Z46DVUnzdso0aX4KckKw0FNNFHdjZ2UsZvxiA==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /p-finally/1.0.0:
+    resolution: { integrity: sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-P7z7FbiZpEEjs0ttzBi3JDNqLK4=
+
   /p-limit/2.3.0:
+    resolution:
+      {
+        integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       p-try: 2.2.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==
+
   /p-limit/3.1.0:
+    resolution:
+      {
+        integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       yocto-queue: 0.1.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==
+
   /p-locate/3.0.0:
+    resolution:
+      {
+        integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       p-limit: 2.3.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-x+12w/To+4GFfgJhBEpiDcLozRJGegY+Ei7/z0tSLkMmxGZNybVMSfWj9aJn8Z5Fc7dBUNJOOVgPv2H7IwulSQ==
+
   /p-locate/4.1.0:
+    resolution:
+      {
+        integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       p-limit: 2.3.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==
+
   /p-locate/5.0.0:
+    resolution:
+      {
+        integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       p-limit: 3.1.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
+
   /p-map/2.1.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==
+      {
+        integrity: sha512-y3b8Kpd8OAN444hxfBbFfj1FY/RjtTd8tzYwhUqNYXx0fXx2iX4maP4Qr6qhIKbQXI02wTLAda4fYUbDagTUFw==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /p-map/4.0.0:
+    resolution:
+      {
+        integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       aggregate-error: 3.1.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-/bjOqmgETBYB5BoEeGVea8dmvHb2m9GLy1E9W43yeyfP6QQCZGFNa+XRceJEuDB6zqr+gKpIAmlLebMpykw/MQ==
+
   /p-try/2.2.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==
+      {
+        integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /package-json/6.5.0:
+    resolution:
+      {
+        integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       got: 9.6.0
       registry-auth-token: 4.2.1
       registry-url: 5.1.0
       semver: 6.3.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-k3bdm2n25tkyxcjSKzB5x8kfVxlMdgsbPr0GkZcwHsLpba6cBjqCt1KlcChKEvxHIcTB1FVMuwoijZ26xex5MQ==
+
   /pacote/11.2.3:
+    resolution:
+      {
+        integrity: sha512-Jphxyk1EjGyLzNwa+MkbcQUQeTIqlKcIoPq0t9ekR9ZxsTGjzhRjz/cOoL9PTVkqAW1FH7qBoVbYL4FqQGNNJg==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
     dependencies:
       "@npmcli/git": 2.0.4
       "@npmcli/installed-package-contents": 1.0.5
@@ -6154,207 +7657,243 @@ packages:
       rimraf: 3.0.2
       ssri: 8.0.0
       tar: 6.1.0
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">=10"
-    hasBin: true
-    resolution:
-      integrity: sha512-Jphxyk1EjGyLzNwa+MkbcQUQeTIqlKcIoPq0t9ekR9ZxsTGjzhRjz/cOoL9PTVkqAW1FH7qBoVbYL4FqQGNNJg==
+
   /parent-module/1.0.1:
+    resolution:
+      {
+        integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       callsites: 3.1.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==
+
   /parse-json/4.0.0:
+    resolution: { integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA= }
+    engines: { node: ">=4" }
     dependencies:
       error-ex: 1.3.2
       json-parse-better-errors: 1.0.2
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=
+
   /parse-json/5.2.0:
+    resolution:
+      {
+        integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       "@babel/code-frame": 7.12.11
       error-ex: 1.3.2
       json-parse-even-better-errors: 2.3.1
       lines-and-columns: 1.1.6
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-ayCKvm/phCGxOkYRSCM82iDwct8/EonSEgCSxWxD7ve6jHggsFl4fZVQBPRNgQoKiuV/odhFrGzQXZwbifC8Rg==
+
   /parse5/5.1.1:
-    dev: true
     resolution:
-      integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==
+      {
+        integrity: sha512-ugq4DFI0Ptb+WWjAdOK16+u/nHfiIrcE+sh8kZMaM0WllQKLI9rOUq6c2b7cwPkXdzfQESqvoqK6ug7U/Yyzug==,
+      }
+    dev: true
+
   /parse5/6.0.1:
+    resolution:
+      {
+        integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==,
+      }
     dev: false
-    resolution:
-      integrity: sha512-Ofn/CTFzRGTTxwpNEs9PP93gXShHcTq255nzRYSKe8AkVpZY7e1fpmTfOyoIvjP5HG7Z2ZM7VS9PPhQGW2pOpw==
+
   /pascalcase/0.1.1:
+    resolution: { integrity: sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-s2PlXoAGym/iF4TS2yK9FdeRfxQ=
+
   /path-exists/3.0.0:
+    resolution: { integrity: sha1-zg6+ql94yxiSXqfYENe1mwEP1RU= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-zg6+ql94yxiSXqfYENe1mwEP1RU=
+
   /path-exists/4.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==
+      {
+        integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /path-is-absolute/1.0.1:
+    resolution: { integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-F0uSaHNVNP+8es5r9TpanhtcX18=
+
   /path-key/2.0.1:
+    resolution: { integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-QRyttXTFoUDTpLGRDUDYDMn0C0A=
+
   /path-key/3.1.1:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==
+      {
+        integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /path-parse/1.0.6:
-    dev: true
     resolution:
-      integrity: sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==
+      {
+        integrity: sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==,
+      }
+    dev: true
+
   /path-type/4.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==
+      {
+        integrity: sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /pend/1.2.0:
+    resolution: { integrity: sha1-elfrVQpng/kRUzH89GY9XI4AelA= }
     dev: true
-    resolution:
-      integrity: sha1-elfrVQpng/kRUzH89GY9XI4AelA=
+
   /performance-now/2.1.0:
+    resolution: { integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns= }
     dev: true
-    resolution:
-      integrity: sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=
+
   /picomatch/2.2.2:
-    dev: true
-    engines:
-      node: ">=8.6"
     resolution:
-      integrity: sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==
+      {
+        integrity: sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==,
+      }
+    engines: { node: ">=8.6" }
+    dev: true
+
   /pify/2.3.0:
+    resolution: { integrity: sha1-7RQaasBDqEnqWISY59yosVMw6Qw= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-7RQaasBDqEnqWISY59yosVMw6Qw=
+
   /pify/3.0.0:
+    resolution: { integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=
+
   /pirates/4.0.1:
+    resolution:
+      {
+        integrity: sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==,
+      }
+    engines: { node: ">= 6" }
     dependencies:
       node-modules-regexp: 1.0.0
     dev: true
-    engines:
-      node: ">= 6"
-    resolution:
-      integrity: sha512-WuNqLTbMI3tmfef2TKxlQmAiLHKtFhlsCZnPIpuv2Ow0RDVO8lfy1Opf4NUzlMXLjPl+Men7AuVdX6TA+s+uGA==
+
   /pkg-dir/4.2.0:
+    resolution:
+      {
+        integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       find-up: 4.1.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==
+
   /pkg-dir/5.0.0:
+    resolution:
+      {
+        integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       find-up: 5.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-NPE8TDbzl/3YQYY7CSS228s3g2ollTFnc+Qi3tqmqJp9Vg2ovUpixcJEo2HJScN2Ez+kEaal6y70c0ehqJBJeA==
+
   /please-upgrade-node/3.2.0:
+    resolution:
+      {
+        integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==,
+      }
     dependencies:
       semver-compare: 1.0.0
     dev: true
-    resolution:
-      integrity: sha512-gQR3WpIgNIKwBMVLkpMUeR3e1/E1y42bqDQZfql+kDeXd8COYfM8PQA4X6y7a8u9Ua9FHmsrrmirW2vHs45hWg==
+
   /plur/4.0.0:
+    resolution:
+      {
+        integrity: sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       irregular-plurals: 3.2.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-4UGewrYgqDFw9vV6zNV+ADmPAUAfJPKtGvb/VdpQAx25X5f3xXdGdyOEVFwkl8Hl/tl7+xbeHqSEM+D5/TirUg==
+
   /posix-character-classes/0.1.1:
+    resolution: { integrity: sha1-AerA/jta9xoqbAL+q7jB/vfgDqs= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-AerA/jta9xoqbAL+q7jB/vfgDqs=
+
   /prelude-ls/1.1.2:
+    resolution: { integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ= }
+    engines: { node: ">= 0.8.0" }
     dev: true
-    engines:
-      node: ">= 0.8.0"
-    resolution:
-      integrity: sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
+
   /prelude-ls/1.2.1:
-    dev: true
-    engines:
-      node: ">= 0.8.0"
     resolution:
-      integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==
+      {
+        integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==,
+      }
+    engines: { node: ">= 0.8.0" }
+    dev: true
+
   /prepend-http/2.0.0:
+    resolution: { integrity: sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-6SQ0v6XqjBn0HN/UAddBo8gZ2Jc=
+
   /prettier/2.2.1:
-    dev: true
-    engines:
-      node: ">=10.13.0"
+    resolution:
+      {
+        integrity: sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==,
+      }
+    engines: { node: ">=10.13.0" }
     hasBin: true
-    resolution:
-      integrity: sha512-PqyhM2yCjg/oKkFPtTGUojv7gnZAoG80ttl45O6x2Ug/rMJw4wcc9k6aaf2hibP7BGVCCM33gZoGjyvt9mm16Q==
-  /pretty-bytes/5.5.0:
     dev: true
-    engines:
-      node: ">=6"
+
+  /pretty-bytes/5.5.0:
     resolution:
-      integrity: sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==
+      {
+        integrity: sha512-p+T744ZyjjiaFlMUZZv6YPC5JrkNj8maRmPaQCWFJFplUAzpIUTRaTcS+7wmZtUoFXHtESJb23ISliaWyz3SHA==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /pretty-format/26.6.2:
+    resolution:
+      {
+        integrity: sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==,
+      }
+    engines: { node: ">= 10" }
     dependencies:
       "@jest/types": 26.6.2
       ansi-regex: 5.0.0
       ansi-styles: 4.3.0
       react-is: 17.0.1
     dev: true
-    engines:
-      node: ">= 10"
-    resolution:
-      integrity: sha512-7AeGuCYNGmycyQbCqd/3PWH4eOoX/OiCa0uphp57NVTeAGdJGaAliecxwBDHYQCIvrW7aDBZCYeNTP/WX69mkg==
+
   /pretty-quick/3.1.0_prettier@2.2.1:
+    resolution:
+      {
+        integrity: sha512-DtxIxksaUWCgPFN7E1ZZk4+Aav3CCuRdhrDSFZENb404sYMtuo9Zka823F+Mgeyt8Zt3bUiCjFzzWYE9LYqkmQ==,
+      }
+    engines: { node: ">=10.13" }
+    hasBin: true
+    peerDependencies:
+      prettier: ">=2.0.0"
     dependencies:
       chalk: 3.0.0
       execa: 4.1.0
@@ -6364,172 +7903,211 @@ packages:
       multimatch: 4.0.0
       prettier: 2.2.1
     dev: true
-    engines:
-      node: ">=10.13"
-    hasBin: true
-    peerDependencies:
-      prettier: ">=2.0.0"
-    resolution:
-      integrity: sha512-DtxIxksaUWCgPFN7E1ZZk4+Aav3CCuRdhrDSFZENb404sYMtuo9Zka823F+Mgeyt8Zt3bUiCjFzzWYE9LYqkmQ==
+
   /process-nextick-args/2.0.1:
-    dev: true
     resolution:
-      integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==
+      {
+        integrity: sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==,
+      }
+    dev: true
+
   /progress/2.0.3:
-    dev: true
-    engines:
-      node: ">=0.4.0"
     resolution:
-      integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==
+      {
+        integrity: sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==,
+      }
+    engines: { node: ">=0.4.0" }
+    dev: true
+
   /promise-inflight/1.0.1:
+    resolution: { integrity: sha1-mEcocL8igTL8vdhoEputEsPAKeM= }
     dev: true
-    resolution:
-      integrity: sha1-mEcocL8igTL8vdhoEputEsPAKeM=
+
   /promise-retry/1.1.1:
+    resolution: { integrity: sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0= }
+    engines: { node: ">=0.12" }
     dependencies:
       err-code: 1.1.2
       retry: 0.10.1
     dev: true
-    engines:
-      node: ">=0.12"
-    resolution:
-      integrity: sha1-ZznpaOMFHaIM5kl/srUPaRHfPW0=
+
   /prompts/2.4.0:
+    resolution:
+      {
+        integrity: sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==,
+      }
+    engines: { node: ">= 6" }
     dependencies:
       kleur: 3.0.3
       sisteransi: 1.0.5
     dev: true
-    engines:
-      node: ">= 6"
-    resolution:
-      integrity: sha512-awZAKrk3vN6CroQukBL+R9051a4R3zCZBlJm/HBfrSZ8iTpYix3VX1vU4mveiLpiwmOJT4wokTF9m6HUk4KqWQ==
+
   /psl/1.8.0:
-    dev: true
     resolution:
-      integrity: sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==
+      {
+        integrity: sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==,
+      }
+    dev: true
+
   /puka/1.0.1:
-    dev: true
-    engines:
-      node: ">=4"
     resolution:
-      integrity: sha512-ssjRZxBd7BT3dte1RR3VoeT2cT/ODH8x+h0rUF1rMqB0srHYf48stSDWfiYakTp5UBZMxroZhB2+ExLDHm7W3g==
+      {
+        integrity: sha512-ssjRZxBd7BT3dte1RR3VoeT2cT/ODH8x+h0rUF1rMqB0srHYf48stSDWfiYakTp5UBZMxroZhB2+ExLDHm7W3g==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /pump/3.0.0:
+    resolution:
+      {
+        integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==,
+      }
     dependencies:
       end-of-stream: 1.4.4
       once: 1.4.0
     dev: true
-    resolution:
-      integrity: sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==
+
   /punycode/1.3.2:
+    resolution: { integrity: sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0= }
     dev: true
-    resolution:
-      integrity: sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0=
+
   /punycode/2.1.1:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
+      {
+        integrity: sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /pupa/2.1.1:
+    resolution:
+      {
+        integrity: sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       escape-goat: 2.1.1
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
+
   /qs/6.5.2:
-    dev: true
-    engines:
-      node: ">=0.6"
     resolution:
-      integrity: sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==
+      {
+        integrity: sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==,
+      }
+    engines: { node: ">=0.6" }
+    dev: true
+
   /querystring/0.2.0:
+    resolution: { integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA= }
+    engines: { node: ">=0.4.x" }
     dev: true
-    engines:
-      node: ">=0.4.x"
-    resolution:
-      integrity: sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=
+
   /quick-lru/4.0.1:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+      {
+        integrity: sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /ramda/0.26.1:
-    dev: true
     resolution:
-      integrity: sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==
+      {
+        integrity: sha512-hLWjpy7EnsDBb0p+Z3B7rPi3GDeRG5ZtiI33kJhTt+ORCd38AbAIjB/9zRIUoeTbE/AVX5ZkU7m6bznsvrf8eQ==,
+      }
+    dev: true
+
   /randombytes/2.1.0:
+    resolution:
+      {
+        integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==,
+      }
     dependencies:
       safe-buffer: 5.2.1
     dev: true
-    resolution:
-      integrity: sha512-vYl3iOX+4CKUWuxGi9Ukhie6fsqXqS9FE2Zaic4tNFD2N2QQaXOMFbuKK4QmDHC0JO6B1Zp41J0LpT0oR68amQ==
+
   /rc/1.2.8:
+    resolution:
+      {
+        integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==,
+      }
+    hasBin: true
     dependencies:
       deep-extend: 0.6.0
       ini: 1.3.8
       minimist: 1.2.5
       strip-json-comments: 2.0.1
     dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==
+
   /react-is/17.0.1:
-    dev: true
     resolution:
-      integrity: sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
+      {
+        integrity: sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==,
+      }
+    dev: true
+
   /read-package-json-fast/1.2.1:
+    resolution:
+      {
+        integrity: sha512-OFbpwnHcv74Oa5YN5WvbOBfLw6yPmPcwvyJJw/tj9cWFBF7juQUDLDSZiOjEcgzfweWeeROOmbPpNN1qm4hcRg==,
+      }
     dependencies:
       json-parse-even-better-errors: 2.3.1
       npm-normalize-package-bin: 1.0.1
     dev: true
-    resolution:
-      integrity: sha512-OFbpwnHcv74Oa5YN5WvbOBfLw6yPmPcwvyJJw/tj9cWFBF7juQUDLDSZiOjEcgzfweWeeROOmbPpNN1qm4hcRg==
+
   /read-package-json/3.0.0:
+    resolution:
+      {
+        integrity: sha512-4TnJZ5fnDs+/3deg1AuMExL4R1SFNRLQeOhV9c8oDKm3eoG6u8xU0r0mNNRJHi3K6B+jXmT7JOhwhAklWw9SSQ==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       glob: 7.1.6
       json-parse-even-better-errors: 2.3.1
       normalize-package-data: 3.0.0
       npm-normalize-package-bin: 1.0.1
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-4TnJZ5fnDs+/3deg1AuMExL4R1SFNRLQeOhV9c8oDKm3eoG6u8xU0r0mNNRJHi3K6B+jXmT7JOhwhAklWw9SSQ==
+
   /read-pkg-up/7.0.1:
+    resolution:
+      {
+        integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       find-up: 4.1.0
       read-pkg: 5.2.0
       type-fest: 0.8.1
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-zK0TB7Xd6JpCLmlLmufqykGE+/TlOePD6qKClNW7hHDKFh/J7/7gCWGR7joEQEW1bKq3a3yUZSObOoWLFQ4ohg==
+
   /read-pkg/4.0.1:
+    resolution: { integrity: sha1-ljYlN48+HE1IyFhytabsfV0JMjc= }
+    engines: { node: ">=6" }
     dependencies:
       normalize-package-data: 2.5.0
       parse-json: 4.0.0
       pify: 3.0.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha1-ljYlN48+HE1IyFhytabsfV0JMjc=
+
   /read-pkg/5.2.0:
+    resolution:
+      {
+        integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       "@types/normalize-package-data": 2.4.0
       normalize-package-data: 2.5.0
       parse-json: 5.2.0
       type-fest: 0.6.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-Ug69mNOpfvKDAc2Q8DRpMjjzdtrnv9HcSMX+4VsZxD1aZ6ZzrIE7rlzXBtWTyhULSMKg076AW6WR5iZpD0JiOg==
+
   /readable-stream/2.3.7:
+    resolution:
+      {
+        integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==,
+      }
     dependencies:
       core-util-is: 1.0.2
       inherits: 2.0.4
@@ -6539,74 +8117,100 @@ packages:
       string_decoder: 1.1.1
       util-deprecate: 1.0.2
     dev: true
-    resolution:
-      integrity: sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==
+
   /readable-stream/3.6.0:
+    resolution:
+      {
+        integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==,
+      }
+    engines: { node: ">= 6" }
     dependencies:
       inherits: 2.0.4
       string_decoder: 1.3.0
       util-deprecate: 1.0.2
     dev: true
-    engines:
-      node: ">= 6"
-    resolution:
-      integrity: sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==
+
   /readdir-scoped-modules/1.1.0:
+    resolution:
+      {
+        integrity: sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==,
+      }
     dependencies:
       debuglog: 1.0.1
       dezalgo: 1.0.3
       graceful-fs: 4.2.4
       once: 1.4.0
     dev: true
-    resolution:
-      integrity: sha512-asaikDeqAQg7JifRsZn1NJZXo9E+VwlyCfbkZhwyISinqk5zNS6266HS5kah6P0SaQKGF6SkNnZVHUzHFYxYDw==
+
   /redent/3.0.0:
+    resolution:
+      {
+        integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       indent-string: 4.0.0
       strip-indent: 3.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==
+
   /regenerate-unicode-properties/8.2.0:
+    resolution:
+      {
+        integrity: sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==,
+      }
+    engines: { node: ">=4" }
     dependencies:
       regenerate: 1.4.2
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha512-F9DjY1vKLo/tPePDycuH3dn9H1OTPIkVD9Kz4LODu+F2C75mgjAJ7x/gwy6ZcSNRAAkhNlJSOHRe8k3p+K9WhA==
+
   /regenerate/1.4.2:
-    dev: true
     resolution:
-      integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
+      {
+        integrity: sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==,
+      }
+    dev: true
+
   /regenerator-runtime/0.13.7:
-    dev: true
     resolution:
-      integrity: sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==
+      {
+        integrity: sha512-a54FxoJDIr27pgf7IgeQGxmqUNYrcV338lf/6gH456HZ/PhX+5BcwHXG9ajESmwe6WRO0tAzRUrRmNONWgkrew==,
+      }
+    dev: true
+
   /regenerator-transform/0.14.5:
+    resolution:
+      {
+        integrity: sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==,
+      }
     dependencies:
       "@babel/runtime": 7.12.5
     dev: true
-    resolution:
-      integrity: sha512-eOf6vka5IO151Jfsw2NO9WpGX58W6wWmefK3I1zEGr0lOD0u8rwPaNqQL1aRxUaxLeKO3ArNh3VYg1KbaD+FFw==
+
   /regex-not/1.0.2:
+    resolution:
+      {
+        integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       extend-shallow: 3.0.2
       safe-regex: 1.1.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-J6SDjUgDxQj5NusnOtdFxDwN/+HWykR8GELwctJ7mdqhcyy1xEc4SRFHUXvxTp661YaVKAjfRLZ9cCqS6tn32A==
+
   /regexpp/3.1.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==
+      {
+        integrity: sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /regexpu-core/4.7.1:
+    resolution:
+      {
+        integrity: sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==,
+      }
+    engines: { node: ">=4" }
     dependencies:
       regenerate: 1.4.2
       regenerate-unicode-properties: 8.2.0
@@ -6615,85 +8219,103 @@ packages:
       unicode-match-property-ecmascript: 1.0.4
       unicode-match-property-value-ecmascript: 1.2.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha512-ywH2VUraA44DZQuRKzARmw6S66mr48pQVva4LBeRhcOltJ6hExvWly5ZjFLYo67xbIxb6W1q4bAGtgfEl20zfQ==
+
   /registry-auth-token/4.2.1:
+    resolution:
+      {
+        integrity: sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==,
+      }
+    engines: { node: ">=6.0.0" }
     dependencies:
       rc: 1.2.8
     dev: true
-    engines:
-      node: ">=6.0.0"
-    resolution:
-      integrity: sha512-6gkSb4U6aWJB4SF2ZvLb76yCBjcvufXBqvvEx1HbmKPkutswjW1xNVRY0+daljIYRbogN7O0etYSlbiaEQyMyw==
+
   /registry-url/5.1.0:
+    resolution:
+      {
+        integrity: sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       rc: 1.2.8
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-8acYXXTI0AkQv6RAOjE3vOaIXZkT9wo4LOFbBKYQEEnnMNBpKqdUrI6S4NT0KPIo/WVvJ5tE/X5LF/TQUf0ekw==
+
   /regjsgen/0.5.2:
-    dev: true
     resolution:
-      integrity: sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==
+      {
+        integrity: sha512-OFFT3MfrH90xIW8OOSyUrk6QHD5E9JOTeGodiJeBS3J6IwlgzJMNE/1bZklWz5oTg+9dCMyEetclvCVXOPoN3A==,
+      }
+    dev: true
+
   /regjsparser/0.6.6:
+    resolution:
+      {
+        integrity: sha512-jjyuCp+IEMIm3N1H1LLTJW1EISEJV9+5oHdEyrt43Pg9cDSb6rrLZei2cVWpl0xTjmmlpec/lEQGYgM7xfpGCQ==,
+      }
+    hasBin: true
     dependencies:
       jsesc: 0.5.0
     dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-jjyuCp+IEMIm3N1H1LLTJW1EISEJV9+5oHdEyrt43Pg9cDSb6rrLZei2cVWpl0xTjmmlpec/lEQGYgM7xfpGCQ==
+
   /remove-trailing-separator/1.1.0:
+    resolution: { integrity: sha1-wkvOKig62tW8P1jg1IJJuSN52O8= }
     dev: true
-    resolution:
-      integrity: sha1-wkvOKig62tW8P1jg1IJJuSN52O8=
+
   /repeat-element/1.1.3:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==
+      {
+        integrity: sha512-ahGq0ZnV5m5XtZLMb+vP76kcAM5nkLqk0lpqAuojSKGgQtn4eRi4ZZGm2olo2zKFH+sMsWaqOCW1dqAnOru72g==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /repeat-string/1.6.1:
+    resolution: { integrity: sha1-jcrkcOHIirwtYA//Sndihtp15jc= }
+    engines: { node: ">=0.10" }
     dev: true
-    engines:
-      node: ">=0.10"
-    resolution:
-      integrity: sha1-jcrkcOHIirwtYA//Sndihtp15jc=
+
   /request-progress/3.0.0:
+    resolution: { integrity: sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4= }
     dependencies:
       throttleit: 1.0.0
     dev: true
-    resolution:
-      integrity: sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=
+
   /request-promise-core/1.1.4_request@2.88.2:
+    resolution:
+      {
+        integrity: sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==,
+      }
+    engines: { node: ">=0.10.0" }
+    peerDependencies:
+      request: ^2.34
     dependencies:
       lodash: 4.17.20
       request: 2.88.2
     dev: true
-    engines:
-      node: ">=0.10.0"
+
+  /request-promise-native/1.0.9_request@2.88.2:
+    resolution:
+      {
+        integrity: sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==,
+      }
+    engines: { node: ">=0.12.0" }
+    deprecated: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
     peerDependencies:
       request: ^2.34
-    resolution:
-      integrity: sha512-TTbAfBBRdWD7aNNOoVOBH4pN/KigV6LyapYNNlAPA8JwbovRti1E88m3sYAwsLi5ryhPKsE9APwnjFTgdUjTpw==
-  /request-promise-native/1.0.9_request@2.88.2:
     dependencies:
       request: 2.88.2
       request-promise-core: 1.1.4_request@2.88.2
       stealthy-require: 1.1.1
       tough-cookie: 2.5.0
-    deprecated: request-promise-native has been deprecated because it extends the now deprecated request package, see https://github.com/request/request/issues/3142
     dev: true
-    engines:
-      node: ">=0.12.0"
-    peerDependencies:
-      request: ^2.34
-    resolution:
-      integrity: sha512-wcW+sIUiWnKgNY0dqCpOZkUbF/I+YPi+f09JZIDa39Ec+q82CpSYniDp+ISgTTbKmnpJWASeJBPZmoxH84wt3g==
+
   /request/2.88.2:
+    resolution:
+      {
+        integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==,
+      }
+    engines: { node: ">= 6" }
+    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
     dependencies:
       aws-sign2: 0.7.0
       aws4: 1.11.0
@@ -6715,131 +8337,155 @@ packages:
       tough-cookie: 2.5.0
       tunnel-agent: 0.6.0
       uuid: 3.4.0
-    deprecated: request has been deprecated, see https://github.com/request/request/issues/3142
     dev: true
-    engines:
-      node: ">= 6"
-    resolution:
-      integrity: sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==
+
   /require-directory/2.1.1:
+    resolution: { integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-jGStX9MNqxyXbiNE/+f3kqam30I=
+
   /require-from-string/2.0.2:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==
+      {
+        integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /require-main-filename/2.0.0:
-    dev: true
     resolution:
-      integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==
+      {
+        integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==,
+      }
+    dev: true
+
   /resolve-cwd/3.0.0:
+    resolution:
+      {
+        integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       resolve-from: 5.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-OrZaX2Mb+rJCpH/6CpSqt9xFVpN++x01XnN2ie9g6P5/3xelLAkXWVADpdz1IHD/KFfEXyE6V0U01OQ3UO2rEg==
+
   /resolve-from/4.0.0:
-    dev: true
-    engines:
-      node: ">=4"
     resolution:
-      integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==
+      {
+        integrity: sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /resolve-from/5.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
+      {
+        integrity: sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /resolve-url/0.2.1:
+    resolution: { integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo= }
     deprecated: https://github.com/lydell/resolve-url#deprecated
     dev: true
-    resolution:
-      integrity: sha1-LGN/53yJOv0qZj/iGqkIAGjiBSo=
+
   /resolve/1.19.0:
+    resolution:
+      {
+        integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==,
+      }
     dependencies:
       is-core-module: 2.2.0
       path-parse: 1.0.6
     dev: true
-    resolution:
-      integrity: sha512-rArEXAgsBG4UgRGcynxWIWKFvh/XZCcS8UJdHhwy91zwAvCZIbcs+vAbflgBnNjYMs/i/i+/Ux6IZhML1yPvxg==
+
   /resolve/2.0.0-next.2:
+    resolution:
+      {
+        integrity: sha512-oHC2H45OCkhIeS45uW5zCsSinW+hgWwRtfobOhmkXiO4Q6e6fpZpBuBkZxAqTfoC1O6VIclqK6RjyeGVaxEYtA==,
+      }
     dependencies:
       is-core-module: 2.2.0
       path-parse: 1.0.6
     dev: true
-    resolution:
-      integrity: sha512-oHC2H45OCkhIeS45uW5zCsSinW+hgWwRtfobOhmkXiO4Q6e6fpZpBuBkZxAqTfoC1O6VIclqK6RjyeGVaxEYtA==
+
   /responselike/1.0.2:
+    resolution: { integrity: sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec= }
     dependencies:
       lowercase-keys: 1.0.1
     dev: true
-    resolution:
-      integrity: sha1-kYcg7ztjHFZCvgaPFa3lpG9Loec=
+
   /restore-cursor/1.0.1:
+    resolution: { integrity: sha1-NGYfRohjJ/7SmRR5FSJS35LapUE= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       exit-hook: 1.1.1
       onetime: 1.1.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-NGYfRohjJ/7SmRR5FSJS35LapUE=
+
   /restore-cursor/2.0.0:
+    resolution: { integrity: sha1-n37ih/gv0ybU/RYpI9YhKe7g368= }
+    engines: { node: ">=4" }
     dependencies:
       onetime: 2.0.1
       signal-exit: 3.0.3
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-n37ih/gv0ybU/RYpI9YhKe7g368=
+
   /ret/0.1.15:
-    dev: true
-    engines:
-      node: ">=0.12"
     resolution:
-      integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==
+      {
+        integrity: sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==,
+      }
+    engines: { node: ">=0.12" }
+    dev: true
+
   /retry/0.10.1:
+    resolution: { integrity: sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q= }
     dev: true
-    resolution:
-      integrity: sha1-52OI0heZLCUnUCQdPTlW/tmNj/Q=
+
   /reusify/1.0.4:
-    dev: true
-    engines:
-      iojs: ">=1.0.0"
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==
+      {
+        integrity: sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==,
+      }
+    engines: { iojs: ">=1.0.0", node: ">=0.10.0" }
+    dev: true
+
   /rimraf/2.7.1:
+    resolution:
+      {
+        integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==,
+      }
+    hasBin: true
     dependencies:
       glob: 7.1.6
     dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-uWjbaKIK3T1OSVptzX7Nl6PvQ3qAGtKEtVRjRuazjfL3Bx5eI409VZSqgND+4UNnmzLVdPj9FqFJNPqBZFve4w==
+
   /rimraf/3.0.2:
+    resolution:
+      {
+        integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==,
+      }
+    hasBin: true
     dependencies:
       glob: 7.1.6
     dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
+
   /rollup-cli/1.0.9:
+    resolution: { integrity: sha1-N/ShwgYxHikuMpfql3eduKIduZQ= }
+    engines: { node: ">=5.0.0" }
     deprecated: outdated
-    dev: true
-    engines:
-      node: ">=5.0.0"
     hasBin: true
-    resolution:
-      integrity: sha1-N/ShwgYxHikuMpfql3eduKIduZQ=
+    dev: true
+
   /rollup-plugin-terser/7.0.2_rollup@2.38.0:
+    resolution:
+      {
+        integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==,
+      }
+    peerDependencies:
+      rollup: ^2.0.0
     dependencies:
       "@babel/code-frame": 7.12.11
       jest-worker: 26.6.2
@@ -6847,56 +8493,77 @@ packages:
       serialize-javascript: 4.0.0
       terser: 5.5.1
     dev: true
-    peerDependencies:
-      rollup: ^2.0.0
-    resolution:
-      integrity: sha512-w3iIaU4OxcF52UUXiZNsNeuXIMDvFrr+ZXK6bFZ0Q60qyVfq4uLptoS4bbq3paG3x216eQllFZX7zt6TIImguQ==
+
   /rollup/2.38.0:
-    dev: true
-    engines:
-      node: ">=10.0.0"
+    resolution:
+      {
+        integrity: sha512-ay9zDiNitZK/LNE/EM2+v5CZ7drkB2xyDljvb1fQJCGnq43ZWRkhxN145oV8GmoW1YNi4sA/1Jdkr2LfawJoXw==,
+      }
+    engines: { node: ">=10.0.0" }
     hasBin: true
     optionalDependencies:
       fsevents: 2.1.3
-    resolution:
-      integrity: sha512-ay9zDiNitZK/LNE/EM2+v5CZ7drkB2xyDljvb1fQJCGnq43ZWRkhxN145oV8GmoW1YNi4sA/1Jdkr2LfawJoXw==
+    dev: true
+
   /rsvp/4.8.5:
-    dev: true
-    engines:
-      node: 6.* || >= 7.*
     resolution:
-      integrity: sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==
+      {
+        integrity: sha512-nfMOlASu9OnRJo1mbEk2cz0D56a1MBNrJ7orjRZQG10XDyuvwksKbuXNp6qa+kbn839HwjwhBzhFmdsaEAfauA==,
+      }
+    engines: { node: 6.* || >= 7.* }
+    dev: true
+
   /run-parallel/1.1.10:
-    dev: true
     resolution:
-      integrity: sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==
+      {
+        integrity: sha512-zb/1OuZ6flOlH6tQyMPUrE3x3Ulxjlo9WIVXR4yVYi4H9UXQaeIsPbLn2R3O3vQCnDKkAl2qHiuocKKX4Tz/Sw==,
+      }
+    dev: true
+
   /rxjs/6.6.3:
+    resolution:
+      {
+        integrity: sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==,
+      }
+    engines: { npm: ">=2.0.0" }
     dependencies:
       tslib: 1.14.1
     dev: true
-    engines:
-      npm: ">=2.0.0"
-    resolution:
-      integrity: sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
+
   /safe-buffer/5.1.2:
-    dev: true
     resolution:
-      integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
+      {
+        integrity: sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==,
+      }
+    dev: true
+
   /safe-buffer/5.2.1:
-    dev: true
     resolution:
-      integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
+      {
+        integrity: sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==,
+      }
+    dev: true
+
   /safe-regex/1.1.0:
+    resolution: { integrity: sha1-QKNmnzsHfR6UPURinhV91IAjvy4= }
     dependencies:
       ret: 0.1.15
     dev: true
-    resolution:
-      integrity: sha1-QKNmnzsHfR6UPURinhV91IAjvy4=
+
   /safer-buffer/2.1.2:
-    dev: true
     resolution:
-      integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
+      {
+        integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==,
+      }
+    dev: true
+
   /sane/4.1.0:
+    resolution:
+      {
+        integrity: sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==,
+      }
+    engines: { node: 6.* || 8.* || >= 10.* }
+    hasBin: true
     dependencies:
       "@cnakazawa/watch": 1.0.4
       anymatch: 2.0.0
@@ -6908,175 +8575,220 @@ packages:
       minimist: 1.2.5
       walker: 1.0.7
     dev: true
-    engines:
-      node: 6.* || 8.* || >= 10.*
-    hasBin: true
-    resolution:
-      integrity: sha512-hhbzAgTIX8O7SHfp2c8/kREfEn4qO/9q8C9beyY6+tvZ87EpoZ3i1RIEvp27YBswnNbY9mWd6paKVmKbAgLfZA==
+
   /saxes/5.0.1:
+    resolution:
+      {
+        integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       xmlchars: 2.2.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-5LBh1Tls8c9xgGjw3QrMwETmTMVk0oFgvrFSvWx62llR2hcEInrKNZ2GZCCuuy2lvWrdl5jhbpeqc5hRYKFOcw==
+
   /semver-compare/1.0.0:
+    resolution: { integrity: sha1-De4hahyUGrN+nvsXiPavxf9VN/w= }
     dev: true
-    resolution:
-      integrity: sha1-De4hahyUGrN+nvsXiPavxf9VN/w=
+
   /semver-diff/3.1.1:
+    resolution:
+      {
+        integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       semver: 6.3.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-GX0Ix/CJcHyB8c4ykpHGIAvLyOwOobtM/8d+TQkAd81/bEjgPHrfba41Vpesr7jX/t8Uh+R3EX9eAS5be+jQYg==
+
   /semver-regex/3.1.2:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==
+      {
+        integrity: sha512-bXWyL6EAKOJa81XG1OZ/Yyuq+oT0b2YLlxx7c+mrdYPaPbnj6WgVULXhinMIeZGufuUBu/eVRqXEhiv4imfwxA==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /semver/5.7.1:
-    dev: true
-    hasBin: true
     resolution:
-      integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==
+      {
+        integrity: sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==,
+      }
+    hasBin: true
+    dev: true
+
   /semver/6.3.0:
-    dev: true
-    hasBin: true
     resolution:
-      integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==
+      {
+        integrity: sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==,
+      }
+    hasBin: true
+    dev: true
+
   /semver/7.0.0:
-    dev: true
-    hasBin: true
     resolution:
-      integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==
+      {
+        integrity: sha512-+GB6zVA9LWh6zovYQLALHwv5rb2PHGlJi3lfiqIHxR0uuwCgefcOJc59v9fv1w8GbStwxuuqqAjI9NMAOOgq1A==,
+      }
+    hasBin: true
+    dev: true
+
   /semver/7.3.4:
+    resolution:
+      {
+        integrity: sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
     dependencies:
       lru-cache: 6.0.0
     dev: true
-    engines:
-      node: ">=10"
-    hasBin: true
-    resolution:
-      integrity: sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==
+
   /serialize-javascript/4.0.0:
+    resolution:
+      {
+        integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==,
+      }
     dependencies:
       randombytes: 2.1.0
     dev: true
-    resolution:
-      integrity: sha512-GaNA54380uFefWghODBWEGisLZFj00nS5ACs6yHa9nLqlLpVLO8ChDGeKRjZnV4Nh4n0Qi7nhYZD/9fCPzEqkw==
+
   /set-blocking/2.0.0:
+    resolution: { integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc= }
     dev: true
-    resolution:
-      integrity: sha1-BF+XgtARrppoA93TgrJDkrPYkPc=
+
   /set-value/2.0.1:
+    resolution:
+      {
+        integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       extend-shallow: 2.0.1
       is-extendable: 0.1.1
       is-plain-object: 2.0.4
       split-string: 3.1.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-JxHc1weCN68wRY0fhCoXpyK55m/XPHafOmK4UWD7m2CI14GMcFypt4w/0+NV5f/ZMby2F6S2wwA7fgynh9gWSw==
+
   /shebang-command/1.2.0:
+    resolution: { integrity: sha1-RKrGW2lbAzmJaMOfNj/uXer98eo= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       shebang-regex: 1.0.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=
+
   /shebang-command/2.0.0:
+    resolution:
+      {
+        integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       shebang-regex: 3.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==
+
   /shebang-regex/1.0.0:
+    resolution: { integrity: sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-2kL0l0DAtC2yypcoVxyxkMmO/qM=
+
   /shebang-regex/3.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==
+      {
+        integrity: sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /shellwords/0.1.1:
+    resolution:
+      {
+        integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==,
+      }
     dev: true
     optional: true
-    resolution:
-      integrity: sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==
+
   /signal-exit/3.0.3:
-    dev: true
     resolution:
-      integrity: sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==
+      {
+        integrity: sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==,
+      }
+    dev: true
+
   /single-spa/5.9.0:
-    dev: true
     resolution:
-      integrity: sha512-GhOceK36ruH8hhGFR7o3kkbrhoRG0m8/Ygsr16/qJ60El5OSz2WCYL4BFvX9nHwH2jpzgCqgoOWH9O5+So2dvQ==
+      {
+        integrity: sha512-GhOceK36ruH8hhGFR7o3kkbrhoRG0m8/Ygsr16/qJ60El5OSz2WCYL4BFvX9nHwH2jpzgCqgoOWH9O5+So2dvQ==,
+      }
+    dev: true
+
   /sisteransi/1.0.5:
-    dev: true
     resolution:
-      integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==
+      {
+        integrity: sha512-bLGGlR1QxBcynn2d5YmDX4MGjlZvy2MRBDRNHLJ8VI6l6+9FUiyTFNJ0IveOSP0bcXgVDPRcfGqA0pjaqUpfVg==,
+      }
+    dev: true
+
   /slash/3.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==
+      {
+        integrity: sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /slice-ansi/0.0.4:
+    resolution: { integrity: sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-7b+JA/ZvfOL46v1s7tZeJkyDGzU=
+
   /slice-ansi/4.0.0:
+    resolution:
+      {
+        integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       ansi-styles: 4.3.0
       astral-regex: 2.0.0
       is-fullwidth-code-point: 3.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-qMCMfhY040cVHT43K9BFygqYbUPFZKHOg7K73mtTWJRb8pyP3fzf4Ixd5SzdEJQ6MRUg/WBnOLxghZtKKurENQ==
+
   /smart-buffer/4.1.0:
-    dev: true
-    engines:
-      node: ">= 6.0.0"
-      npm: ">= 3.0.0"
     resolution:
-      integrity: sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==
+      {
+        integrity: sha512-iVICrxOzCynf/SNaBQCw34eM9jROU/s5rzIhpOvzhzuYHfJR/DhZfDkXiZSgKXfgv26HT3Yni3AV/DGw0cGnnw==,
+      }
+    engines: { node: ">= 6.0.0", npm: ">= 3.0.0" }
+    dev: true
+
   /snapdragon-node/2.1.1:
+    resolution:
+      {
+        integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       define-property: 1.0.0
       isobject: 3.0.1
       snapdragon-util: 3.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==
+
   /snapdragon-util/3.0.1:
+    resolution:
+      {
+        integrity: sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       kind-of: 3.2.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==
+
   /snapdragon/0.8.2:
+    resolution:
+      {
+        integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       base: 0.11.2
       debug: 2.6.9
@@ -7087,31 +8799,37 @@ packages:
       source-map-resolve: 0.5.3
       use: 3.1.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-FtyOnWN/wCHTVXOMwvSv26d+ko5vWlIDD6zoUJ7LW8vh+ZBC8QdljveRP+crNrtBwioEUWy/4dMtbBjA4ioNlg==
+
   /socks-proxy-agent/5.0.0:
+    resolution:
+      {
+        integrity: sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==,
+      }
+    engines: { node: ">= 6" }
     dependencies:
       agent-base: 6.0.2
       debug: 4.3.1
       socks: 2.5.1
+    transitivePeerDependencies:
+      - supports-color
     dev: true
-    engines:
-      node: ">= 6"
-    resolution:
-      integrity: sha512-lEpa1zsWCChxiynk+lCycKuC502RxDWLKJZoIhnxrWNjLSDGYRFflHA1/228VkRcnv9TIb8w98derGbpKxJRgA==
+
   /socks/2.5.1:
+    resolution:
+      {
+        integrity: sha512-oZCsJJxapULAYJaEYBSzMcz8m3jqgGrHaGhkmU/o/PQfFWYWxkAaA0UMGImb6s6tEXfKi959X6VJjMMQ3P6TTQ==,
+      }
+    engines: { node: ">= 10.13.0", npm: ">= 3.0.0" }
     dependencies:
       ip: 1.1.5
       smart-buffer: 4.1.0
     dev: true
-    engines:
-      node: ">= 10.13.0"
-      npm: ">= 3.0.0"
-    resolution:
-      integrity: sha512-oZCsJJxapULAYJaEYBSzMcz8m3jqgGrHaGhkmU/o/PQfFWYWxkAaA0UMGImb6s6tEXfKi959X6VJjMMQ3P6TTQ==
+
   /source-map-resolve/0.5.3:
+    resolution:
+      {
+        integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==,
+      }
     dependencies:
       atob: 2.1.2
       decode-uri-component: 0.2.0
@@ -7119,87 +8837,118 @@ packages:
       source-map-url: 0.4.0
       urix: 0.1.0
     dev: true
-    resolution:
-      integrity: sha512-Htz+RnsXWk5+P2slx5Jh3Q66vhQj1Cllm0zvnaY98+NFx+Dv2CF/f5O/t8x+KaNdrdIAsruNzoh/KpialbqAnw==
+
   /source-map-resolve/0.6.0:
+    resolution:
+      {
+        integrity: sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==,
+      }
     dependencies:
       atob: 2.1.2
       decode-uri-component: 0.2.0
     dev: true
-    resolution:
-      integrity: sha512-KXBr9d/fO/bWo97NXsPIAW1bFSBOuCnjbNTBMO7N59hsv5i9yzRDfcYwwt0l04+VqnKC+EwzvJZIP/qkuMgR/w==
+
   /source-map-support/0.5.19:
+    resolution:
+      {
+        integrity: sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==,
+      }
     dependencies:
       buffer-from: 1.1.1
       source-map: 0.6.1
     dev: true
-    resolution:
-      integrity: sha512-Wonm7zOCIJzBGQdB+thsPar0kYuCIzYvxZwlBa87yi/Mdjv7Tip2cyVbLj5o0cFPN4EVkuTwb3GDDyUx2DGnGw==
+
   /source-map-url/0.4.0:
+    resolution: { integrity: sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM= }
     dev: true
-    resolution:
-      integrity: sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=
+
   /source-map/0.5.7:
+    resolution: { integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=
+
   /source-map/0.6.1:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==
+      {
+        integrity: sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /source-map/0.7.3:
-    dev: true
-    engines:
-      node: ">= 8"
     resolution:
-      integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==
+      {
+        integrity: sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==,
+      }
+    engines: { node: ">= 8" }
+    dev: true
+
   /sourcemap-codec/1.4.8:
-    dev: true
     resolution:
-      integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==
+      {
+        integrity: sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==,
+      }
+    dev: true
+
   /spawn-command/0.0.2-1:
+    resolution: { integrity: sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A= }
     dev: true
-    resolution:
-      integrity: sha1-YvXpRmmBwbeW3Fkpk34RycaSG9A=
+
   /spdx-correct/3.1.1:
+    resolution:
+      {
+        integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==,
+      }
     dependencies:
       spdx-expression-parse: 3.0.1
       spdx-license-ids: 3.0.7
     dev: true
-    resolution:
-      integrity: sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==
+
   /spdx-exceptions/2.3.0:
-    dev: true
     resolution:
-      integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==
+      {
+        integrity: sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==,
+      }
+    dev: true
+
   /spdx-expression-parse/3.0.1:
+    resolution:
+      {
+        integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==,
+      }
     dependencies:
       spdx-exceptions: 2.3.0
       spdx-license-ids: 3.0.7
     dev: true
-    resolution:
-      integrity: sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==
+
   /spdx-license-ids/3.0.7:
-    dev: true
     resolution:
-      integrity: sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==
+      {
+        integrity: sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==,
+      }
+    dev: true
+
   /split-string/3.1.0:
+    resolution:
+      {
+        integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       extend-shallow: 3.0.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==
+
   /sprintf-js/1.0.3:
+    resolution: { integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw= }
     dev: true
-    resolution:
-      integrity: sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=
+
   /sshpk/1.16.1:
+    resolution:
+      {
+        integrity: sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==,
+      }
+    engines: { node: ">=0.10.0" }
+    hasBin: true
     dependencies:
       asn1: 0.2.4
       assert-plus: 1.0.0
@@ -7211,247 +8960,291 @@ packages:
       safer-buffer: 2.1.2
       tweetnacl: 0.14.5
     dev: true
-    engines:
-      node: ">=0.10.0"
-    hasBin: true
-    resolution:
-      integrity: sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==
+
   /ssri/8.0.0:
+    resolution:
+      {
+        integrity: sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==,
+      }
+    engines: { node: ">= 8" }
     dependencies:
       minipass: 3.1.3
     dev: true
-    engines:
-      node: ">= 8"
-    resolution:
-      integrity: sha512-aq/pz989nxVYwn16Tsbj1TqFpD5LLrQxHf5zaHuieFV+R0Bbr4y8qUsOA45hXT/N4/9UNXTarBjnjVmjSOVaAA==
+
   /stack-utils/2.0.3:
+    resolution:
+      {
+        integrity: sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       escape-string-regexp: 2.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-gL//fkxfWUsIlFL2Tl42Cl6+HFALEaB1FU76I/Fy+oZjRreP7OPMXFlGbxM7NQsI0ZpUfw76sHnv0WNYuTb7Iw==
+
   /static-extend/0.1.2:
+    resolution: { integrity: sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       define-property: 0.2.5
       object-copy: 0.1.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=
+
   /stealthy-require/1.1.1:
+    resolution: { integrity: sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-NbCYdbT/SfJqd35QmzCQoyJr8ks=
+
   /string-length/4.0.1:
+    resolution:
+      {
+        integrity: sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       char-regex: 1.0.2
       strip-ansi: 6.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-PKyXUd0LK0ePjSOnWn34V2uD6acUWev9uy0Ft05k0E8xRW+SKcA0F7eMr7h5xlzfn+4O3N+55rduYyet3Jk+jw==
+
   /string-width/1.0.2:
+    resolution: { integrity: sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       code-point-at: 1.1.0
       is-fullwidth-code-point: 1.0.0
       strip-ansi: 3.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=
+
   /string-width/2.1.1:
+    resolution:
+      {
+        integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==,
+      }
+    engines: { node: ">=4" }
     dependencies:
       is-fullwidth-code-point: 2.0.0
       strip-ansi: 4.0.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==
+
   /string-width/3.1.0:
+    resolution:
+      {
+        integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       emoji-regex: 7.0.3
       is-fullwidth-code-point: 2.0.0
       strip-ansi: 5.2.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-vafcv6KjVZKSgz06oM/H6GDBrAtz8vdhQakGjFIvNrHA6y3HCF1CInLy+QLq8dTJPQ1b+KDUqDFctkdRW44e1w==
+
   /string-width/4.2.0:
+    resolution:
+      {
+        integrity: sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       emoji-regex: 8.0.0
       is-fullwidth-code-point: 3.0.0
       strip-ansi: 6.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-zUz5JD+tgqtuDjMhwIg5uFVV3dtqZ9yQJlZVfq4I01/K5Paj5UHj7VyrQOJvzawSVlKpObApbfD0Ed6yJc+1eg==
+
   /string.prototype.trimend/1.0.3:
+    resolution:
+      {
+        integrity: sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==,
+      }
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
     dev: true
-    resolution:
-      integrity: sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==
+
   /string.prototype.trimstart/1.0.3:
+    resolution:
+      {
+        integrity: sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==,
+      }
     dependencies:
       call-bind: 1.0.2
       define-properties: 1.1.3
     dev: true
-    resolution:
-      integrity: sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==
+
   /string_decoder/1.1.1:
+    resolution:
+      {
+        integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==,
+      }
     dependencies:
       safe-buffer: 5.1.2
     dev: true
-    resolution:
-      integrity: sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==
+
   /string_decoder/1.3.0:
+    resolution:
+      {
+        integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==,
+      }
     dependencies:
       safe-buffer: 5.2.1
     dev: true
-    resolution:
-      integrity: sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==
+
   /strip-ansi/3.0.1:
+    resolution: { integrity: sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       ansi-regex: 2.1.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=
+
   /strip-ansi/4.0.0:
+    resolution: { integrity: sha1-qEeQIusaw2iocTibY1JixQXuNo8= }
+    engines: { node: ">=4" }
     dependencies:
       ansi-regex: 3.0.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-qEeQIusaw2iocTibY1JixQXuNo8=
+
   /strip-ansi/5.2.0:
+    resolution:
+      {
+        integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       ansi-regex: 4.1.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==
+
   /strip-ansi/6.0.0:
+    resolution:
+      {
+        integrity: sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       ansi-regex: 5.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-AuvKTrTfQNYNIctbR1K/YGTR1756GycPsg7b9bdV9Duqur4gv6aKqHXah67Z8ImS7WEz5QVcOtlfW2rZEugt6w==
+
   /strip-bom/4.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
+      {
+        integrity: sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /strip-eof/1.0.0:
+    resolution: { integrity: sha1-u0P/VZim6wXYm1n80SnJgzE2Br8= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-u0P/VZim6wXYm1n80SnJgzE2Br8=
+
   /strip-final-newline/2.0.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==
+      {
+        integrity: sha512-BrpvfNAE3dcvq7ll3xVumzjKjZQ5tI1sEUIKr3Uoks0XUl45St3FlatVqef9prk4jRDzhW6WZg+3bk93y6pLjA==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /strip-indent/3.0.0:
+    resolution:
+      {
+        integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       min-indent: 1.0.1
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==
+
   /strip-json-comments/2.0.1:
+    resolution: { integrity: sha1-PFMZQukIwml8DsNEhYwobHygpgo= }
+    engines: { node: ">=0.10.0" }
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
   /strip-json-comments/3.1.1:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==
+      {
+        integrity: sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /supports-color/2.0.0:
+    resolution: { integrity: sha1-U10EXOa2Nj+kARcIRimZXp3zJMc= }
+    engines: { node: ">=0.8.0" }
     dev: true
-    engines:
-      node: ">=0.8.0"
-    resolution:
-      integrity: sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
+
   /supports-color/5.5.0:
+    resolution:
+      {
+        integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==,
+      }
+    engines: { node: ">=4" }
     dependencies:
       has-flag: 3.0.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
+
   /supports-color/6.1.0:
+    resolution:
+      {
+        integrity: sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       has-flag: 3.0.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-qe1jfm1Mg7Nq/NSh6XE24gPXROEVsWHxC1LIx//XNlD9iw7YZQGjZNjYN7xGaEG6iKdA8EtNFW6R0gjnVXp+wQ==
+
   /supports-color/7.2.0:
+    resolution:
+      {
+        integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       has-flag: 4.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==
+
   /supports-hyperlinks/2.1.0:
+    resolution:
+      {
+        integrity: sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       has-flag: 4.0.0
       supports-color: 7.2.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-zoE5/e+dnEijk6ASB6/qrK+oYdm2do1hjoLWrqUC/8WEIW1gbxFcKuBof7sW8ArN6e+AYvsE8HBGiVRWL/F5CA==
+
   /symbol-observable/1.2.0:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==
+      {
+        integrity: sha512-e900nM8RRtGhlV36KGEU9k65K3mPb1WV70OdjfxlG2EAuM1noi/E/BaW/uMhL7bPEssK8QV57vN3esixjUvcXQ==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /symbol-tree/3.2.4:
-    dev: true
     resolution:
-      integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==
+      {
+        integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==,
+      }
+    dev: true
+
   /table/6.0.7:
+    resolution:
+      {
+        integrity: sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==,
+      }
+    engines: { node: ">=10.0.0" }
     dependencies:
       ajv: 7.0.3
       lodash: 4.17.20
       slice-ansi: 4.0.0
       string-width: 4.2.0
     dev: true
-    engines:
-      node: ">=10.0.0"
-    resolution:
-      integrity: sha512-rxZevLGTUzWna/qBLObOe16kB2RTnnbhciwgPbMMlazz1yZGVEgnZK762xyVdVznhqxrfCeBMmMkgOOaPwjH7g==
+
   /tar/6.1.0:
+    resolution:
+      {
+        integrity: sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==,
+      }
+    engines: { node: ">= 10" }
     dependencies:
       chownr: 2.0.0
       fs-minipass: 2.1.0
@@ -7460,163 +9253,193 @@ packages:
       mkdirp: 1.0.4
       yallist: 4.0.0
     dev: true
-    engines:
-      node: ">= 10"
-    resolution:
-      integrity: sha512-DUCttfhsnLCjwoDoFcI+B2iJgYa93vBnDUATYEeRx6sntCTdN01VnqsIuTlALXla/LWooNg0yEGeB+Y8WdFxGA==
+
   /term-size/2.2.1:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
+      {
+        integrity: sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /terminal-link/2.1.1:
+    resolution:
+      {
+        integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       ansi-escapes: 4.3.1
       supports-hyperlinks: 2.1.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-un0FmiRUQNr5PJqy9kP7c40F5BOfpGlYTrxonDChEZB7pzZxRNp/bt+ymiy9/npwXya9KH99nJ/GXFIiUkYGFQ==
+
   /terser/5.5.1:
+    resolution:
+      {
+        integrity: sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
     dependencies:
       commander: 2.20.3
       source-map: 0.7.3
       source-map-support: 0.5.19
     dev: true
-    engines:
-      node: ">=10"
-    hasBin: true
-    resolution:
-      integrity: sha512-6VGWZNVP2KTUcltUQJ25TtNjx/XgdDsBDKGt8nN0MpydU36LmbPPcMBd2kmtZNNGVVDLg44k7GKeHHj+4zPIBQ==
+
   /test-exclude/6.0.0:
+    resolution:
+      {
+        integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       "@istanbuljs/schema": 0.1.2
       glob: 7.1.6
       minimatch: 3.0.4
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-cAGWPIyOHU6zlmg88jwm7VRyXnMN7iV68OGAbYDk/Mh/xC/pzVPlQtY6ngoIH/5/tciuhGfvESU8GrHrcxD56w==
+
   /text-table/0.2.0:
+    resolution: { integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ= }
     dev: true
-    resolution:
-      integrity: sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=
+
   /throat/5.0.0:
-    dev: true
     resolution:
-      integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==
+      {
+        integrity: sha512-fcwX4mndzpLQKBS1DVYhGAcYaYt7vsHNIvQV+WXMvnow5cgjPphq5CaayLaGsjRdSCKZFNGt7/GYAuXaNOiYCA==,
+      }
+    dev: true
+
   /throttleit/1.0.0:
+    resolution: { integrity: sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw= }
     dev: true
-    resolution:
-      integrity: sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw=
+
   /tmp/0.2.1:
+    resolution:
+      {
+        integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==,
+      }
+    engines: { node: ">=8.17.0" }
     dependencies:
       rimraf: 3.0.2
     dev: true
-    engines:
-      node: ">=8.17.0"
-    resolution:
-      integrity: sha512-76SUhtfqR2Ijn+xllcI5P1oyannHNHByD80W1q447gU3mp9G9PSpGdWmjUOHRDPiHYacIk66W7ubDTuPF3BEtQ==
+
   /tmpl/1.0.4:
+    resolution: { integrity: sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE= }
     dev: true
-    resolution:
-      integrity: sha1-I2QN17QtAEM5ERQIIOXPRA5SHdE=
+
   /to-fast-properties/2.0.0:
+    resolution: { integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4= }
+    engines: { node: ">=4" }
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=
+
   /to-object-path/0.3.0:
+    resolution: { integrity: sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       kind-of: 3.2.2
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=
+
   /to-readable-stream/1.0.0:
-    dev: true
-    engines:
-      node: ">=6"
     resolution:
-      integrity: sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==
+      {
+        integrity: sha512-Iq25XBt6zD5npPhlLVXGFN3/gyR2/qODcKNNyTMd4vbm39HUaOiAM4PMq0eMVC/Tkxz+Zjdsc55g9yyz+Yq00Q==,
+      }
+    engines: { node: ">=6" }
+    dev: true
+
   /to-regex-range/2.1.1:
+    resolution: { integrity: sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       is-number: 3.0.0
       repeat-string: 1.6.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=
+
   /to-regex-range/5.0.1:
+    resolution:
+      {
+        integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==,
+      }
+    engines: { node: ">=8.0" }
     dependencies:
       is-number: 7.0.0
     dev: true
-    engines:
-      node: ">=8.0"
-    resolution:
-      integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==
+
   /to-regex/3.0.2:
+    resolution:
+      {
+        integrity: sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       define-property: 2.0.2
       extend-shallow: 3.0.2
       regex-not: 1.0.2
       safe-regex: 1.1.0
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-FWtleNAtZ/Ki2qtqej2CXTOayOH9bHDQF+Q48VpWyDXjbYxA4Yz8iDB31zXOBUlOHHKidDbqGVrTUvQMPmBGBw==
+
   /tough-cookie/2.5.0:
+    resolution:
+      {
+        integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==,
+      }
+    engines: { node: ">=0.8" }
     dependencies:
       psl: 1.8.0
       punycode: 2.1.1
     dev: true
-    engines:
-      node: ">=0.8"
-    resolution:
-      integrity: sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==
+
   /tough-cookie/3.0.1:
+    resolution:
+      {
+        integrity: sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       ip-regex: 2.1.0
       psl: 1.8.0
       punycode: 2.1.1
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==
+
   /tr46/2.0.2:
+    resolution:
+      {
+        integrity: sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       punycode: 2.1.1
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-3n1qG+/5kg+jrbTzwAykB5yRYtQCTqOGKq5U5PE3b0a1/mzo6snDhjGS0zJVJunO0NrT3Dg1MLy5TjWP/UJppg==
+
   /tree-kill/1.2.2:
-    dev: true
-    hasBin: true
     resolution:
-      integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==
+      {
+        integrity: sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==,
+      }
+    hasBin: true
+    dev: true
+
   /tree-walk/0.4.0:
+    resolution: { integrity: sha1-6s4Rm9+fOjlFJ16Dj5hi5pxfBks= }
     dependencies:
       util-extend: 1.0.3
     dev: true
-    resolution:
-      integrity: sha1-6s4Rm9+fOjlFJ16Dj5hi5pxfBks=
+
   /trim-newlines/3.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==
+      {
+        integrity: sha512-C4+gOpvmxaSMKuEf9Qc134F1ZuOHVXKRbtEflf4NTtuuJDEIJ9p5PXsalL8SkeRw+qit1Mo+yuvMPAKwWg/1hA==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /tsd/0.13.1:
+    resolution:
+      {
+        integrity: sha512-+UYM8LRG/M4H8ISTg2ow8SWi65PS7Os+4DUnyiQLbJysXBp2DEmws9SMgBH+m8zHcJZqUJQ+mtDWJXP1IAvB2A==,
+      }
+    engines: { node: ">=10" }
+    hasBin: true
     dependencies:
       eslint-formatter-pretty: 4.0.0
       globby: 11.0.2
@@ -7625,168 +9448,209 @@ packages:
       read-pkg-up: 7.0.1
       update-notifier: 4.1.3
     dev: true
-    engines:
-      node: ">=10"
-    hasBin: true
-    resolution:
-      integrity: sha512-+UYM8LRG/M4H8ISTg2ow8SWi65PS7Os+4DUnyiQLbJysXBp2DEmws9SMgBH+m8zHcJZqUJQ+mtDWJXP1IAvB2A==
+
   /tslib/1.14.1:
-    dev: true
     resolution:
-      integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+      {
+        integrity: sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==,
+      }
+    dev: true
+
   /tunnel-agent/0.6.0:
+    resolution: { integrity: sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0= }
     dependencies:
       safe-buffer: 5.2.1
     dev: true
-    resolution:
-      integrity: sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=
+
   /tweetnacl/0.14.5:
+    resolution: { integrity: sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q= }
     dev: true
-    resolution:
-      integrity: sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=
+
   /type-check/0.3.2:
+    resolution: { integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I= }
+    engines: { node: ">= 0.8.0" }
     dependencies:
       prelude-ls: 1.1.2
     dev: true
-    engines:
-      node: ">= 0.8.0"
-    resolution:
-      integrity: sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=
+
   /type-check/0.4.0:
+    resolution:
+      {
+        integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==,
+      }
+    engines: { node: ">= 0.8.0" }
     dependencies:
       prelude-ls: 1.2.1
     dev: true
-    engines:
-      node: ">= 0.8.0"
-    resolution:
-      integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==
+
   /type-detect/4.0.8:
-    dev: true
-    engines:
-      node: ">=4"
     resolution:
-      integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==
+      {
+        integrity: sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /type-fest/0.11.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==
+      {
+        integrity: sha512-OdjXJxnCN1AvyLSzeKIgXTXxV+99ZuXl3Hpo9XpJAv9MBcHrrJOQ5kV7ypXOuQie+AmWG25hLbiKdwYTifzcfQ==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /type-fest/0.13.1:
-    dev: true
-    engines:
-      node: ">=10"
     resolution:
-      integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==
+      {
+        integrity: sha512-34R7HTnG0XIJcBSn5XhDd7nNFPRcXYRZrBB2O2jdKqYODldSzBAqzsWoZYYvduky73toYS/ESqxPvkDf/F0XMg==,
+      }
+    engines: { node: ">=10" }
+    dev: true
+
   /type-fest/0.6.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==
+      {
+        integrity: sha512-q+MB8nYR1KDLrgr4G5yemftpMC7/QLqVndBmEEdqzmNj5dcFOO4Oo8qlwZE3ULT3+Zim1F8Kq4cBnikNhlCMlg==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /type-fest/0.8.1:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==
+      {
+        integrity: sha512-4dbzIzqvjtgiM5rw1k5rEHtBANKmdudhGyBEajN01fEyhaAIhsoKNy6y7+IN93IfpFtwY9iqi7kD+xwKhQsNJA==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /typedarray-to-buffer/3.1.5:
+    resolution:
+      {
+        integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==,
+      }
     dependencies:
       is-typedarray: 1.0.0
     dev: true
-    resolution:
-      integrity: sha512-zdu8XMNEDepKKR+XYOXAVPtWui0ly0NtohUscw+UmaHiAWT8hrV1rr//H6V+0DvJ3OQ19S979M0laLfX8rm82Q==
+
   /typedarray/0.0.6:
+    resolution: { integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c= }
     dev: true
-    resolution:
-      integrity: sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
+
   /typescript/4.1.3:
-    dev: true
-    engines:
-      node: ">=4.2.0"
+    resolution:
+      {
+        integrity: sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==,
+      }
+    engines: { node: ">=4.2.0" }
     hasBin: true
-    resolution:
-      integrity: sha512-B3ZIOf1IKeH2ixgHhj6la6xdwR9QrLC5d1VKeCSY4tvkqhF2eqd9O7txNlS0PO3GrBAFIdr3L1ndNwteUbZLYg==
-  /unicode-canonical-property-names-ecmascript/1.0.4:
     dev: true
-    engines:
-      node: ">=4"
+
+  /unicode-canonical-property-names-ecmascript/1.0.4:
     resolution:
-      integrity: sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==
+      {
+        integrity: sha512-jDrNnXWHd4oHiTZnx/ZG7gtUTVp+gCcTTKr8L0HjlwphROEW3+Him+IpvC+xcJEFegapiMZyZe02CyuOnRmbnQ==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /unicode-match-property-ecmascript/1.0.4:
+    resolution:
+      {
+        integrity: sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==,
+      }
+    engines: { node: ">=4" }
     dependencies:
       unicode-canonical-property-names-ecmascript: 1.0.4
       unicode-property-aliases-ecmascript: 1.1.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha512-L4Qoh15vTfntsn4P1zqnHulG0LdXgjSO035fEpdtp6YxXhMT51Q6vgM5lYdG/5X3MjS+k/Y9Xw4SFCY9IkR0rg==
+
   /unicode-match-property-value-ecmascript/1.2.0:
-    dev: true
-    engines:
-      node: ">=4"
     resolution:
-      integrity: sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==
+      {
+        integrity: sha512-wjuQHGQVofmSJv1uVISKLE5zO2rNGzM/KCYZch/QQvez7C1hUhBIuZ701fYXExuufJFMPhv2SyL8CyoIfMLbIQ==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /unicode-property-aliases-ecmascript/1.1.0:
-    dev: true
-    engines:
-      node: ">=4"
     resolution:
-      integrity: sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==
+      {
+        integrity: sha512-PqSoPh/pWetQ2phoj5RLiaqIk4kCNwoV3CI+LfGmWLKI3rE3kl1h59XpX2BjgDrmbxD9ARtQobPGU1SguCYuQg==,
+      }
+    engines: { node: ">=4" }
+    dev: true
+
   /union-value/1.0.1:
+    resolution:
+      {
+        integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==,
+      }
+    engines: { node: ">=0.10.0" }
     dependencies:
       arr-union: 3.1.0
       get-value: 2.0.6
       is-extendable: 0.1.1
       set-value: 2.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha512-tJfXmxMeWYnczCVs7XAEvIV7ieppALdyepWMkHkwciRpZraG/xwT+s2JN8+pr1+8jCRf80FFzvr+MpQeeoF4Xg==
+
   /unique-filename/1.1.1:
+    resolution:
+      {
+        integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==,
+      }
     dependencies:
       unique-slug: 2.0.2
     dev: true
-    resolution:
-      integrity: sha512-Vmp0jIp2ln35UTXuryvjzkjGdRyf9b2lTXuSYUiPmzRcl3FDtYqAwOnTJkAngD9SWhnoJzDbTKwaOrZ+STtxNQ==
+
   /unique-slug/2.0.2:
+    resolution:
+      {
+        integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==,
+      }
     dependencies:
       imurmurhash: 0.1.4
     dev: true
-    resolution:
-      integrity: sha512-zoWr9ObaxALD3DOPfjPSqxt4fnZiWblxHIgeWqW8x7UqDzEtHEQLzji2cuJYQFCU6KmoJikOYAZlrTHHebjx2w==
+
   /unique-string/2.0.0:
+    resolution:
+      {
+        integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       crypto-random-string: 2.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-uNaeirEPvpZWSgzwsPGtU2zVSTrn/8L5q/IexZmH0eH6SA73CmAA5U4GwORTxQAZs95TAXLNqeLoPPNO5gZfWg==
+
   /universalify/2.0.0:
-    dev: true
-    engines:
-      node: ">= 10.0.0"
     resolution:
-      integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==
+      {
+        integrity: sha512-hAZsKq7Yy11Zu1DE0OzWjw7nnLZmJZYTDZZyEFHZdUhV8FkH5MCfoU1XMaxXovpyW5nq5scPqq0ZDP9Zyl04oQ==,
+      }
+    engines: { node: ">= 10.0.0" }
+    dev: true
+
   /unset-value/1.0.0:
+    resolution: { integrity: sha1-g3aHP30jNRef+x5vw6jtDfyKtVk= }
+    engines: { node: ">=0.10.0" }
     dependencies:
       has-value: 0.3.1
       isobject: 3.0.1
     dev: true
-    engines:
-      node: ">=0.10.0"
-    resolution:
-      integrity: sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=
+
   /untildify/4.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==
+      {
+        integrity: sha512-KK8xQ1mkzZeg9inewmFVDNkg3l5LUhoq9kN6iWYB/CC9YMG8HA+c1Q8HwDe6dEX7kErrEVNVBO3fWsVq5iDgtw==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /update-notifier/4.1.3:
+    resolution:
+      {
+        integrity: sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       boxen: 4.2.0
       chalk: 3.0.0
@@ -7802,250 +9666,303 @@ packages:
       semver-diff: 3.1.1
       xdg-basedir: 4.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-Yld6Z0RyCYGB6ckIjffGOSOmHXj1gMeE7aROz4MG+XMkmixBX4jUngrGXNYz7wPKBmtoD4MnBa2Anu7RSKht/A==
+
   /uri-js/4.4.1:
+    resolution:
+      {
+        integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==,
+      }
     dependencies:
       punycode: 2.1.1
     dev: true
-    resolution:
-      integrity: sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg==
+
   /urix/0.1.0:
+    resolution: { integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI= }
     deprecated: Please see https://github.com/lydell/urix#deprecated
     dev: true
-    resolution:
-      integrity: sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI=
+
   /url-parse-lax/3.0.0:
+    resolution: { integrity: sha1-FrXK/Afb42dsGxmZF3gj1lA6yww= }
+    engines: { node: ">=4" }
     dependencies:
       prepend-http: 2.0.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=
+
   /url/0.11.0:
+    resolution: { integrity: sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE= }
     dependencies:
       punycode: 1.3.2
       querystring: 0.2.0
     dev: true
-    resolution:
-      integrity: sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=
+
   /use/3.1.1:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==
+      {
+        integrity: sha512-cwESVXlO3url9YWlFW/TA9cshCEhtu7IKJ/p5soJ/gGpj7vbvFrAY/eIioQ6Dw23KjZhYgiIo8HOs1nQ2vr/oQ==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /util-deprecate/1.0.2:
+    resolution: { integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8= }
     dev: true
-    resolution:
-      integrity: sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=
+
   /util-extend/1.0.3:
+    resolution: { integrity: sha1-p8IW0mdUUWljeztu3GypEZ4v+T8= }
     dev: true
-    resolution:
-      integrity: sha1-p8IW0mdUUWljeztu3GypEZ4v+T8=
+
   /uuid/3.4.0:
-    dev: true
-    hasBin: true
     resolution:
-      integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==
+      {
+        integrity: sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==,
+      }
+    hasBin: true
+    dev: true
+
   /uuid/8.3.2:
-    dev: true
+    resolution:
+      {
+        integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==,
+      }
     hasBin: true
-    optional: true
-    resolution:
-      integrity: sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
-  /v8-compile-cache/2.2.0:
     dev: true
+    optional: true
+
+  /v8-compile-cache/2.2.0:
     resolution:
-      integrity: sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==
+      {
+        integrity: sha512-gTpR5XQNKFwOd4clxfnhaqvfqMpqEwr4tOtCyz4MtYZX2JYhfr1JvBFKdS+7K/9rfpZR3VLX+YWBbKoxCgS43Q==,
+      }
+    dev: true
+
   /v8-to-istanbul/7.1.0:
+    resolution:
+      {
+        integrity: sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==,
+      }
+    engines: { node: ">=10.10.0" }
     dependencies:
       "@types/istanbul-lib-coverage": 2.0.3
       convert-source-map: 1.7.0
       source-map: 0.7.3
     dev: true
-    engines:
-      node: ">=10.10.0"
-    resolution:
-      integrity: sha512-uXUVqNUCLa0AH1vuVxzi+MI4RfxEOKt9pBgKwHbgH7st8Kv2P1m+jvWNnektzBh5QShF3ODgKmUFCf38LnVz1g==
+
   /validate-npm-package-license/3.0.4:
+    resolution:
+      {
+        integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==,
+      }
     dependencies:
       spdx-correct: 3.1.1
       spdx-expression-parse: 3.0.1
     dev: true
-    resolution:
-      integrity: sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew==
+
   /validate-npm-package-name/3.0.0:
+    resolution: { integrity: sha1-X6kS2B630MdK/BQN5zF/DKffQ34= }
     dependencies:
       builtins: 1.0.3
     dev: true
-    resolution:
-      integrity: sha1-X6kS2B630MdK/BQN5zF/DKffQ34=
+
   /verror/1.10.0:
+    resolution: { integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA= }
+    engines: { "0": node >=0.6.0 }
     dependencies:
       assert-plus: 1.0.0
       core-util-is: 1.0.2
       extsprintf: 1.3.0
     dev: true
-    engines:
-      "0": node >=0.6.0
-    resolution:
-      integrity: sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=
+
   /w3c-hr-time/1.0.2:
+    resolution:
+      {
+        integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==,
+      }
     dependencies:
       browser-process-hrtime: 1.0.0
     dev: true
-    resolution:
-      integrity: sha512-z8P5DvDNjKDoFIHK7q8r8lackT6l+jo/Ye3HOle7l9nICP9lf1Ci25fy9vHd0JOWewkIFzXIEig3TdKT7JQ5fQ==
+
   /w3c-xmlserializer/2.0.0:
+    resolution:
+      {
+        integrity: sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       xml-name-validator: 3.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-4tzD0mF8iSiMiNs30BiLO3EpfGLZUT2MSX/G+o7ZywDzliWQ3OPtTZ0PTC3B3ca1UAf4cJMHB+2Bf56EriJuRA==
+
   /walker/1.0.7:
+    resolution: { integrity: sha1-L3+bj9ENZ3JisYqITijRlhjgKPs= }
     dependencies:
       makeerror: 1.0.11
     dev: true
-    resolution:
-      integrity: sha1-L3+bj9ENZ3JisYqITijRlhjgKPs=
+
   /webidl-conversions/5.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==
+      {
+        integrity: sha512-VlZwKPCkYKxQgeSbH5EyngOmRp7Ww7I9rQLERETtf5ofd9pGeswWiOtogpEO850jziPRarreGxn5QIiTqpb2wA==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /webidl-conversions/6.1.0:
-    dev: true
-    engines:
-      node: ">=10.4"
     resolution:
-      integrity: sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==
+      {
+        integrity: sha512-qBIvFLGiBpLjfwmYAaHPXsn+ho5xZnGvyGvsarywGNc8VyQJUMHJ8OBKGGrPER0okBeMDaan4mNBlgBROxuI8w==,
+      }
+    engines: { node: ">=10.4" }
+    dev: true
+
   /whatwg-encoding/1.0.5:
+    resolution:
+      {
+        integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==,
+      }
     dependencies:
       iconv-lite: 0.4.24
     dev: true
-    resolution:
-      integrity: sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
+
   /whatwg-mimetype/2.3.0:
-    dev: true
     resolution:
-      integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==
+      {
+        integrity: sha512-M4yMwr6mAnQz76TbJm914+gPpB/nCwvZbJU28cUD6dR004SAxDLOOSUaB1JDRqLtaOV/vi0IC5lEAGFgrjGv/g==,
+      }
+    dev: true
+
   /whatwg-url/8.4.0:
+    resolution:
+      {
+        integrity: sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       lodash.sortby: 4.7.0
       tr46: 2.0.2
       webidl-conversions: 6.1.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-vwTUFf6V4zhcPkWp/4CQPr1TW9Ml6SF4lVyaIMBdJw5i6qUUJ1QWM4Z6YYVkfka0OUIzVo/0aNtGVGk256IKWw==
+
   /which-module/2.0.0:
+    resolution: { integrity: sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho= }
     dev: true
-    resolution:
-      integrity: sha1-2e8H3Od7mQK4o6j6SzHD4/fm6Ho=
+
   /which-pm-runs/1.0.0:
+    resolution: { integrity: sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs= }
     dev: true
-    resolution:
-      integrity: sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=
+
   /which/1.3.1:
+    resolution:
+      {
+        integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==,
+      }
+    hasBin: true
     dependencies:
       isexe: 2.0.0
     dev: true
-    hasBin: true
-    resolution:
-      integrity: sha512-HxJdYWq1MTIQbJ3nw0cqssHoTNU267KlrDuGZ1WYlxDStUtKUhOaJmh112/TZmHxxUfuJqPXSOm7tDyas0OSIQ==
+
   /which/2.0.2:
+    resolution:
+      {
+        integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==,
+      }
+    engines: { node: ">= 8" }
+    hasBin: true
     dependencies:
       isexe: 2.0.0
     dev: true
-    engines:
-      node: ">= 8"
-    hasBin: true
-    resolution:
-      integrity: sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
+
   /wide-align/1.1.3:
+    resolution:
+      {
+        integrity: sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==,
+      }
     dependencies:
       string-width: 1.0.2
     dev: true
-    resolution:
-      integrity: sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==
+
   /widest-line/3.1.0:
+    resolution:
+      {
+        integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       string-width: 4.2.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-NsmoXalsWVDMGupxZ5R08ka9flZjjiLvHVAWYOKtiKM8ujtZWr9cRffak+uSE48+Ob8ObalXpwyeUiyDD6QFgg==
+
   /word-wrap/1.2.3:
-    dev: true
-    engines:
-      node: ">=0.10.0"
     resolution:
-      integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==
+      {
+        integrity: sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==,
+      }
+    engines: { node: ">=0.10.0" }
+    dev: true
+
   /wrap-ansi/3.0.1:
+    resolution: { integrity: sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo= }
+    engines: { node: ">=4" }
     dependencies:
       string-width: 2.1.1
       strip-ansi: 4.0.0
     dev: true
-    engines:
-      node: ">=4"
-    resolution:
-      integrity: sha1-KIoE2H7aXChuBg3+jxNc6NAH+Lo=
+
   /wrap-ansi/5.1.0:
+    resolution:
+      {
+        integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       ansi-styles: 3.2.1
       string-width: 3.1.0
       strip-ansi: 5.2.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-QC1/iN/2/RPVJ5jYK8BGttj5z83LmSKmvbvrXPNCLZSEb32KKVDJDl/MOt2N01qU2H/FkzEa9PKto1BqDjtd7Q==
+
   /wrap-ansi/6.2.0:
+    resolution:
+      {
+        integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.0
       strip-ansi: 6.0.0
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==
+
   /wrap-ansi/7.0.0:
+    resolution:
+      {
+        integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       ansi-styles: 4.3.0
       string-width: 4.2.0
       strip-ansi: 6.0.0
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-YVGIj2kamLSTxw6NsZjoBxfSwsn0ycdesmc4p+Q21c5zPuZ1pl+NfxVdxPtdHvmNVOQ6XSYG4AUtyt/Fi7D16Q==
+
   /wrappy/1.0.2:
+    resolution: { integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8= }
     dev: true
-    resolution:
-      integrity: sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=
+
   /write-file-atomic/3.0.3:
+    resolution:
+      {
+        integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==,
+      }
     dependencies:
       imurmurhash: 0.1.4
       is-typedarray: 1.0.0
       signal-exit: 3.0.3
       typedarray-to-buffer: 3.1.5
     dev: true
-    resolution:
-      integrity: sha512-AvHcyZ5JnSfq3ioSyjrBkH9yW4m7Ayk8/9My/DD9onKeu/94fwrMocemO2QAJFAlnnDN+ZDS+ZjAR5ua1/PV/Q==
+
   /ws/7.4.2:
-    dev: true
-    engines:
-      node: ">=8.3.0"
+    resolution:
+      {
+        integrity: sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==,
+      }
+    engines: { node: ">=8.3.0" }
     peerDependencies:
       bufferutil: ^4.0.1
       utf-8-validate: ^5.0.2
@@ -8054,65 +9971,94 @@ packages:
         optional: true
       utf-8-validate:
         optional: true
-    resolution:
-      integrity: sha512-T4tewALS3+qsrpGI/8dqNMLIVdq/g/85U98HPMa6F0m6xTbvhXU6RCQLqPH3+SlomNV/LdY6RXEbBpMH6EOJnA==
+    dev: true
+
   /xdg-basedir/4.0.0:
-    dev: true
-    engines:
-      node: ">=8"
     resolution:
-      integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==
+      {
+        integrity: sha512-PSNhEJDejZYV7h50BohL09Er9VaIefr2LMAf3OEmpCkjOi34eYyQYAXUTjEQtZJTKcF0E2UKTh+osDLsgNim9Q==,
+      }
+    engines: { node: ">=8" }
+    dev: true
+
   /xml-name-validator/3.0.0:
-    dev: true
     resolution:
-      integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==
+      {
+        integrity: sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==,
+      }
+    dev: true
+
   /xmlchars/2.2.0:
-    dev: true
     resolution:
-      integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==
+      {
+        integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==,
+      }
+    dev: true
+
   /y18n/4.0.1:
-    dev: true
     resolution:
-      integrity: sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==
+      {
+        integrity: sha512-wNcy4NvjMYL8gogWWYAO7ZFWFfHcbdbE57tZO8e4cbpj8tfUcwrwqSl3ad8HxpYWCdXcJUCeKKZS62Av1affwQ==,
+      }
+    dev: true
+
   /y18n/5.0.5:
-    dev: true
-    engines:
-      node: ">=10"
     resolution:
-      integrity: sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==
+      {
+        integrity: sha512-hsRUr4FFrvhhRH12wOdfs38Gy7k2FFzB9qgN9v3aLykRq0dRcdcpz5C9FxdS2NuhOrI/628b/KSTJ3rwHysYSg==,
+      }
+    engines: { node: ">=10" }
+    dev: true
+
   /yallist/4.0.0:
-    dev: true
     resolution:
-      integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==
+      {
+        integrity: sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A==,
+      }
+    dev: true
+
   /yaml/1.10.0:
-    dev: true
-    engines:
-      node: ">= 6"
     resolution:
-      integrity: sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==
+      {
+        integrity: sha512-yr2icI4glYaNG+KWONODapy2/jDdMSDnrONSjblABjD9B4Z5LgiircSt8m8sRZFNi08kG9Sm0uSHtEmP3zaEGg==,
+      }
+    engines: { node: ">= 6" }
+    dev: true
+
   /yargs-parser/13.1.2:
+    resolution:
+      {
+        integrity: sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==,
+      }
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
     dev: true
-    resolution:
-      integrity: sha512-3lbsNRf/j+A4QuSZfDRA7HRSfWrzO0YjqTJd5kjAq37Zep1CEgaYmrH9Q3GwPiB9cHyd1Y1UwggGhJGoxipbzg==
+
   /yargs-parser/18.1.3:
+    resolution:
+      {
+        integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==,
+      }
+    engines: { node: ">=6" }
     dependencies:
       camelcase: 5.3.1
       decamelize: 1.2.0
     dev: true
-    engines:
-      node: ">=6"
-    resolution:
-      integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==
+
   /yargs-parser/20.2.4:
-    dev: true
-    engines:
-      node: ">=10"
     resolution:
-      integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==
+      {
+        integrity: sha512-WOkpgNhPTlE73h4VFAFsOnomJVaovO8VqLDzy5saChRBFQFBoMYirowyW+Q9HB4HFF4Z7VZTiG3iSzJJA29yRA==,
+      }
+    engines: { node: ">=10" }
+    dev: true
+
   /yargs/13.3.2:
+    resolution:
+      {
+        integrity: sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==,
+      }
     dependencies:
       cliui: 5.0.0
       find-up: 3.0.0
@@ -8125,9 +10071,13 @@ packages:
       y18n: 4.0.1
       yargs-parser: 13.1.2
     dev: true
-    resolution:
-      integrity: sha512-AX3Zw5iPruN5ie6xGRIDgqkT+ZhnRlZMLMHAs8tg7nRruy2Nb+i5o9bwghAogtM08q1dpr2LVoS8KSTMYpWXUw==
+
   /yargs/15.4.1:
+    resolution:
+      {
+        integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==,
+      }
+    engines: { node: ">=8" }
     dependencies:
       cliui: 6.0.0
       decamelize: 1.2.0
@@ -8141,11 +10091,13 @@ packages:
       y18n: 4.0.1
       yargs-parser: 18.1.3
     dev: true
-    engines:
-      node: ">=8"
-    resolution:
-      integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==
+
   /yargs/16.2.0:
+    resolution:
+      {
+        integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==,
+      }
+    engines: { node: ">=10" }
     dependencies:
       cliui: 7.0.4
       escalade: 3.1.1
@@ -8155,61 +10107,18 @@ packages:
       y18n: 5.0.5
       yargs-parser: 20.2.4
     dev: true
-    engines:
-      node: ">=10"
-    resolution:
-      integrity: sha512-D1mvvtDG0L5ft/jGWkLpG1+m0eQxOfaBvTNELraWj22wSVUMWxZUvYgJYcKh6jGGIkJFhH4IZPQhR4TKpc8mBw==
+
   /yauzl/2.10.0:
+    resolution: { integrity: sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk= }
     dependencies:
       buffer-crc32: 0.2.13
       fd-slicer: 1.1.0
     dev: true
-    resolution:
-      integrity: sha1-x+sXyT4RLLEIb6bY5R+wZnt5pfk=
+
   /yocto-queue/0.1.0:
-    dev: true
-    engines:
-      node: ">=10"
     resolution:
-      integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-specifiers:
-  "@babel/core": ^7.11.6
-  "@babel/plugin-transform-modules-commonjs": ^7.10.4
-  "@babel/preset-env": ^7.11.5
-  "@rollup/plugin-babel": ^5.2.1
-  "@rollup/plugin-commonjs": ^15.1.0
-  "@rollup/plugin-node-resolve": ^9.0.0
-  "@rollup/plugin-replace": ^2.3.4
-  "@testing-library/dom": ^7.29.4
-  "@testing-library/jest-dom": ^5.11.4
-  "@types/jest": ^26.0.14
-  "@types/jsdom": ^16.2.4
-  "@types/parse5": ^5.0.3
-  "@types/systemjs": ^6.1.0
-  babel-eslint: ^11.0.0-beta.2
-  babel-jest: ^26.3.0
-  concurrently: ^5.3.0
-  cross-env: ^7.0.2
-  cypress: ^5.2.0
-  eslint: ^7.10.0
-  eslint-config-important-stuff: ^1.1.0
-  eslint-config-node-important-stuff: ^1.1.0
-  eslint-plugin-es5: ^1.5.0
-  husky: ^4.3.0
-  jest: ^26.4.2
-  jest-cli: ^26.4.2
-  jest-serializer-html: ^7.0.0
-  js-correct-lockfile: ^1.0.0
-  jsdom: ^16.4.0
-  ls-exports: ^1.0.2
-  merge2: ^1.4.1
-  parse5: ^6.0.1
-  prettier: ^2.1.2
-  pretty-quick: ^3.0.2
-  rimraf: ^3.0.2
-  rollup: ^2.28.2
-  rollup-cli: ^1.0.9
-  rollup-plugin-terser: ^7.0.2
-  single-spa: ^5.9.0
-  tsd: ^0.13.1
-  typescript: ^4.0.3
+      {
+        integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==,
+      }
+    engines: { node: ">=10" }
+    dev: true

--- a/src/browser/constructLayoutEngine.js
+++ b/src/browser/constructLayoutEngine.js
@@ -365,11 +365,22 @@ function findApplicationRoute({ applicationName, location, routes }) {
  */
 function insertNode(node, container, previousSibling) {
   if (previousSibling && previousSibling.nextSibling) {
-    // move to be immediately after previousSibling
-    previousSibling.parentNode.insertBefore(node, previousSibling.nextSibling);
+    // Only call insertBefore() if necessary
+    // https://github.com/single-spa/single-spa-layout/issues/123
+    if (previousSibling.nextSibling !== node) {
+      // move to be immediately after previousSibling
+      previousSibling.parentNode.insertBefore(
+        node,
+        previousSibling.nextSibling
+      );
+    }
   } else {
-    // append to end of the container
-    container.appendChild(node);
+    // Only call appendChild() if necessary
+    // https://github.com/single-spa/single-spa-layout/issues/123
+    if (container.lastChild !== node) {
+      // append to end of the container
+      container.appendChild(node);
+    }
   }
 }
 


### PR DESCRIPTION
See #123. I thought that calling `appendChild()` when the node is already the last child would be a no-op, but it isn't. Apparently that causes the iframe to unmount/remount visually (not sure why). The solution I found is just to avoid calling appendChild() when the node is already the last one in the container.