### PR TITLE
insert dom as first child, by default. Resolves #126.

### DIFF
--- a/src/browser/constructLayoutEngine.js
+++ b/src/browser/constructLayoutEngine.js
@@ -358,29 +358,27 @@ function findApplicationRoute({ applicationName, location, routes }) {
 }
 
 /**
+ * This function inserts a node right after the previousSibling, if provided.
+ * If previousSibling is not provided, this functions inserts the node as the
+ * first child node of container.
  *
  * @param {Node} node
  * @param {Node} container
  * @param {Node=} previousSibling
  */
 function insertNode(node, container, previousSibling) {
-  if (previousSibling && previousSibling.nextSibling) {
-    // Only call insertBefore() if necessary
-    // https://github.com/single-spa/single-spa-layout/issues/123
-    if (previousSibling.nextSibling !== node) {
-      // move to be immediately after previousSibling
-      previousSibling.parentNode.insertBefore(
-        node,
-        previousSibling.nextSibling
-      );
-    }
+  let nextSibling;
+
+  if (previousSibling) {
+    nextSibling = previousSibling.nextSibling;
   } else {
-    // Only call appendChild() if necessary
-    // https://github.com/single-spa/single-spa-layout/issues/123
-    if (container.lastChild !== node) {
-      // append to end of the container
-      container.appendChild(node);
-    }
+    nextSibling = container.firstChild;
+  }
+
+  // Only call insertBefore() if necessary
+  // https://github.com/single-spa/single-spa-layout/issues/123
+  if (nextSibling !== node) {
+    container.insertBefore(node, nextSibling);
   }
 }
 

--- a/src/browser/constructLayoutEngine.js
+++ b/src/browser/constructLayoutEngine.js
@@ -367,13 +367,9 @@ function findApplicationRoute({ applicationName, location, routes }) {
  * @param {Node=} previousSibling
  */
 function insertNode(node, container, previousSibling) {
-  let nextSibling;
-
-  if (previousSibling) {
-    nextSibling = previousSibling.nextSibling;
-  } else {
-    nextSibling = container.firstChild;
-  }
+  const nextSibling = previousSibling
+    ? previousSibling.nextSibling
+    : container.firstChild;
 
   // Only call insertBefore() if necessary
   // https://github.com/single-spa/single-spa-layout/issues/123


### PR DESCRIPTION
See #126.

The cause of the bug is that single-spa-layout was calling `container.appendChild(node)` when `node` was already the firstChild of container, and didn't need to move. The reason is that, when previousSibling is undefined, we defaulted to appending at the end rather than the beginning. Since firstChild nodes don't have a previousSibling, it was always undefined. Since dom nodes are processed in DOM order (first-to-last), this resulted in the following:

1. `single-spa:before-routing-event`

```html
<div>first</div>
<button>second</button>
<span>third</span>
```

2. `single-spa:before-mount-routing-event`, part 1

```html
<button>second</button>
<span>third</span>
<div>first</div>
```

3. `single-spa:before-mount-routing-event`, part 2

```html
<span>third</span>
<div>first</div>
<button>second</button>
```

4. `single-spa:before-mount-routing-event`, part 3

```html
<div>first</div>
<button>second</button>
<span>third</span>
```

5. `single-spa:routing-event`

```html
<div>first</div>
<button>second</button>
<span>third</span>
```

With the changes in this pull request, we never move the dom around during a transition that doesn't require it. So it's a lot more efficient and avoids any unnecessary repaints/reflows. The fix was to default to inserting the node at the **beginning** of the container rather than the **end**, when previousSibling is undefined. This makes a lot more sense, since firstChild nodes don't have a previousSibling and all subsequent nodes do.

No tests broke as a result of this change, which was encouraging to me.