### PR TITLE
Allow class attribute on application node

### DIFF
--- a/src/browser/constructLayoutEngine.js
+++ b/src/browser/constructLayoutEngine.js
@@ -382,20 +382,16 @@ function recurseRoutes({
           applicationElement = document.createElement("div");
           applicationElement.id = htmlId;
         }
-        if (typeof route.classNames === "string") {
-          const elementClassNames = [...applicationElement.classList];
-          const routeClassNames = route.classNames.split(" ");
 
-          elementClassNames.forEach((className) => {
-            if (routeClassNames.indexOf(className) === -1) {
-              applicationElement.classList.remove(className);
-            }
-          });
-          routeClassNames.forEach((className) => {
-            if (elementClassNames.indexOf(className) === -1) {
-              applicationElement.classList.add(className);
-            }
-          });
+        if (typeof route.className === "string") {
+          applicationElement.className = route.className;
+        } else if (
+          typeof route.className !== "string" &&
+          typeof applicationElement.className === "string"
+        ) {
+          // The application element did already exist with previously added classes,
+          // remove the entire attribute to avoid empty class attributes in the DOM.
+          applicationElement.removeAttribute("class");
         }
 
         insertNode(applicationElement, parentContainer, previousSibling);

--- a/src/browser/constructLayoutEngine.js
+++ b/src/browser/constructLayoutEngine.js
@@ -382,6 +382,22 @@ function recurseRoutes({
           applicationElement = document.createElement("div");
           applicationElement.id = htmlId;
         }
+        if (typeof route.classNames === "string") {
+          const elementClassNames = [...applicationElement.classList];
+          const routeClassNames = route.classNames.split(" ");
+
+          elementClassNames.forEach((className) => {
+            if (routeClassNames.indexOf(className) === -1) {
+              applicationElement.classList.remove(className);
+            }
+          });
+          routeClassNames.forEach((className) => {
+            if (elementClassNames.indexOf(className) === -1) {
+              applicationElement.classList.add(className);
+            }
+          });
+        }
+
         insertNode(applicationElement, parentContainer, previousSibling);
         previousSibling = applicationElement;
       }

--- a/src/isomorphic/constructRoutes.js
+++ b/src/isomorphic/constructRoutes.js
@@ -243,9 +243,9 @@ function elementToJson(element, htmlLayoutData, resolvedRoutesConfig) {
       }
     }
 
-    const classNames = getAttribute(element, "class");
-    if (classNames) {
-      application.classNames = classNames;
+    const className = getAttribute(element, "class");
+    if (className) {
+      application.className = className;
     }
 
     setProps(element, application, htmlLayoutData);
@@ -426,7 +426,7 @@ function validateAndSanitize(routesConfig) {
       validateKeys(
         propertyName,
         route,
-        ["type", "name", "props", "loader", "error", "classNames"],
+        ["type", "name", "props", "loader", "error", "className"],
         disableWarnings
       );
       if (route.props) {

--- a/src/isomorphic/constructRoutes.js
+++ b/src/isomorphic/constructRoutes.js
@@ -243,6 +243,11 @@ function elementToJson(element, htmlLayoutData, resolvedRoutesConfig) {
       }
     }
 
+    const classNames = getAttribute(element, "class");
+    if (classNames) {
+      application.classNames = classNames;
+    }
+
     setProps(element, application, htmlLayoutData);
     return [application];
   } else if (element.nodeName.toLowerCase() === "route") {
@@ -421,7 +426,7 @@ function validateAndSanitize(routesConfig) {
       validateKeys(
         propertyName,
         route,
-        ["type", "name", "props", "loader", "error"],
+        ["type", "name", "props", "loader", "error", "classNames"],
         disableWarnings
       );
       if (route.props) {

--- a/src/server/sendLayoutHTTPResponse.js
+++ b/src/server/sendLayoutHTTPResponse.js
@@ -204,7 +204,7 @@ function serializeApplication({
   headerPromises,
 }) {
   const appName = node.name;
-  const appClassNames = typeof node.classNames === "string" && node.classNames;
+  const appClassName = typeof node.className === "string" && node.className;
 
   const propsConfig = node.props || {};
   const propsPromise = Promise.all(
@@ -269,9 +269,9 @@ function serializeApplication({
   assetsStream.add(assetStream);
   bodyStream.add(
     stringStream(
-      appClassNames
-        ? `<div id="single-spa-application:${appName}" class="${appClassNames}">`
-        : `<div id="single-spa-application:${appName}">`
+      `<div id="single-spa-application:${appName}"${
+        appClassName ? ` class="${appClassName}"` : ""
+      }>`
     )
   );
   bodyStream.add(contentStream);

--- a/src/server/sendLayoutHTTPResponse.js
+++ b/src/server/sendLayoutHTTPResponse.js
@@ -204,6 +204,7 @@ function serializeApplication({
   headerPromises,
 }) {
   const appName = node.name;
+  const appClassNames = typeof node.classNames === "string" && node.classNames;
 
   const propsConfig = node.props || {};
   const propsPromise = Promise.all(
@@ -266,7 +267,13 @@ function serializeApplication({
     assetStream = renderError(appName, err);
   }
   assetsStream.add(assetStream);
-  bodyStream.add(stringStream(`<div id="single-spa-application:${appName}">`));
+  bodyStream.add(
+    stringStream(
+      appClassNames
+        ? `<div id="single-spa-application:${appName}" class="${appClassNames}">`
+        : `<div id="single-spa-application:${appName}">`
+    )
+  );
   bodyStream.add(contentStream);
   bodyStream.add(stringStream(`</div>`));
 }

--- a/test/constructRoutes.test.js
+++ b/test/constructRoutes.test.js
@@ -282,7 +282,7 @@ describe("constructRoutes", () => {
       });
       expect(console.warn).toHaveBeenCalled();
       expect(console.warn.mock.calls[0][0].message).toEqual(
-        `Invalid routesConfig.routes[0]: received invalid properties 'somethingElse', but valid properties are type, name, props, loader, error`
+        `Invalid routesConfig.routes[0]: received invalid properties 'somethingElse', but valid properties are type, name, props, loader, error, className`
       );
 
       console.warn.mockReset();
@@ -298,7 +298,7 @@ describe("constructRoutes", () => {
       });
       expect(console.warn).toHaveBeenCalled();
       expect(console.warn.mock.calls[0][0].message).toEqual(
-        `Invalid routesConfig.routes[0]: received invalid properties 'routes', but valid properties are type, name, props, loader, error`
+        `Invalid routesConfig.routes[0]: received invalid properties 'routes', but valid properties are type, name, props, loader, error, className`
       );
     });
 
@@ -338,7 +338,7 @@ describe("constructRoutes", () => {
       });
       expect(console.warn).toHaveBeenCalled();
       expect(console.warn.mock.calls[0][0].message).toEqual(
-        `Invalid routesConfig.routes[0].routes[0]: received invalid properties 'somethingElse', but valid properties are type, name, props, loader, error`
+        `Invalid routesConfig.routes[0].routes[0]: received invalid properties 'somethingElse', but valid properties are type, name, props, loader, error, className`
       );
     });
 


### PR DESCRIPTION
Is there a special reason to why adding class name(s) to the `<application>` element is not supported yet? It seems to work nicely so far and it would definitely be when it comes to design and grid systems as most solutions I've seen so far are rather workarounds.

If not then I'll gladly continue working on this one. Didn't want to go too far before checking in as there might be some reason I just don't know about.