### PR TITLE
Reference TypeScript types in `exports`

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,13 +9,15 @@
     ".": {
       "default": {
         "import": "./dist/esm/single-spa-layout.min.js",
-        "require": "./dist/umd/single-spa-layout.min.cjs"
+        "require": "./dist/umd/single-spa-layout.min.cjs",
+        "types": "dist/types/single-spa-layout-interface.d.ts"
       }
     },
     "./server": {
       "node": {
         "import": "./dist/esm/single-spa-layout-server.min.js",
-        "require": "./dist/umd/single-spa-layout-server.min.cjs"
+        "require": "./dist/umd/single-spa-layout-server.min.cjs",
+        "types": "dist/types/single-spa-layout-server.d.ts"
       }
     }
   },


### PR DESCRIPTION
In TypeScript 4.5, [the `types` field can be used to specify the types for each export](https://devblogs.microsoft.com/typescript/announcing-typescript-4-5-beta/#packagejson-exports-imports-and-self-referencing). This issue was discovered in a [StackOverflow question](https://stackoverflow.com/questions/72473230/error-err-package-path-not-exported-package-subpath-dist-types-single-spa).