### PR TITLE
fix: adjust and replace types for use with new release parse5

### DIFF
--- a/src/browser/constructApplications.js
+++ b/src/browser/constructApplications.js
@@ -17,7 +17,7 @@ import { htmlToParcelConfig } from "../utils/parcel-utils";
  * }} WithLoadFunction
  *
  * @typedef {{
- * [name]: Array<AppRoute>
+ * [name: string]: Array<AppRoute>
  * }} ApplicationMap
  *
  * @typedef {{

--- a/src/isomorphic/constructRoutes.js
+++ b/src/isomorphic/constructRoutes.js
@@ -16,7 +16,7 @@ import { find } from "../utils/find";
 export const MISSING_PROP = typeof Symbol !== "undefined" ? Symbol() : "@";
 
 /**
- * @typedef {InputRoutesConfigObject | Element | import('parse5').DefaultTreeDocument | string} RoutesConfig
+ * @typedef {InputRoutesConfigObject | Element | import('parse5').Document | string} RoutesConfig
  *
  * @typedef {{
  * mode?: string;


### PR DESCRIPTION
ISSUE:  https://github.com/single-spa/single-spa-layout/issues/172

### Resolves: 

I was having trouble building with TS, because of the new versions of the parse5 library.
Because of this, it was suggested to make the adjustment to reflect the new scenario, basically what was done:

- Changed the DefaultTreeDocument property type to Document
- Adjusted the constructApplications property

> Links

https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48402/files#diff-107d402a30275251354f4d0116a2942b4b0631205531ad5ee46c602108ab1836R111

### Attach:

// error

```
node_modules/@types/parse5/index"' has no exported member 'DefaultTreeDocument'.

74 export type RoutesConfig = InputRoutesConfigObject | Element | import('parse5').DefaultTreeDocument | string;
                                                                                   ~~~~~~~~~~~~~~~~~~~
```

![image](https://user-images.githubusercontent.com/4699770/178278642-404014b7-7160-4adf-8c2d-47821ca60af2.png)


PS: This is my first pull request, any misconduct in the creation please let me know so I can adjust and follow the appropriate team standard.