### PR TITLE
Fix - Handle Routing Event - Don't Unmount If Navigation is Cancelled

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "single-spa-layout",
-  "version": "2.1.0",
+  "version": "2.1.1",
   "description": "Layout engine for single-spa applications",
   "main": "dist/umd/single-spa-layout.min.cjs",
   "module": "dist/esm/single-spa-layout.min.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "single-spa-layout",
-  "version": "2.1.1",
+  "version": "2.1.0",
   "description": "Layout engine for single-spa applications",
   "main": "dist/umd/single-spa-layout.min.cjs",
   "module": "dist/esm/single-spa-layout.min.js",

--- a/src/browser/constructLayoutEngine.js
+++ b/src/browser/constructLayoutEngine.js
@@ -204,15 +204,18 @@ export function constructLayoutEngine({
     });
   }
 
-  function handleRoutingEvent({ detail: { newUrl } }) {
-    getAppsToUnmount(newUrl).forEach((name) => {
-      const applicationElement = document.getElementById(
-        applicationElementId(name)
-      );
-      if (applicationElement && applicationElement.isConnected) {
-        applicationElement.parentNode.removeChild(applicationElement);
-      }
-    });
+  function handleRoutingEvent({ detail: { navigationIsCanceled, newUrl } }) {
+    // only unmount if navigation is not cancelled
+    if (!navigationIsCanceled) {
+      getAppsToUnmount(newUrl).forEach((name) => {
+        const applicationElement = document.getElementById(
+          applicationElementId(name)
+        );
+        if (applicationElement && applicationElement.isConnected) {
+          applicationElement.parentNode.removeChild(applicationElement);
+        }
+      });
+    }
   }
 
   /**


### PR DESCRIPTION
This PR addresses a bug brought up in [Issue 151](https://github.com/single-spa/single-spa-layout/issues/151) and [Issue 180](https://github.com/single-spa/single-spa-layout/issues/180).  The bug is around the current app mounted on the screen disappearing when navigation is cancelled while using the single-spa-layout engine.

This issue can be reproduced in [this forked repository](https://github.com/b-ferrari/coexisting-angular-microfrontends) by trying to navigate from application2 to application1.

The fix was to add a small logical check to the `handleRoutingEvent` function in the `constructLayoutEngine` file.  Previously this function was always unmounting the application regardless of navigation state. This change only unmounts the application if navigation is not cancelled.  If navigation is cancelled, the app currently mounted on the screen will remain mounted.

Here is a small gif demonstrating the fix while tracking the window events that the single-spa-layout engine subscribes to:
![2023-06-13_10-39-58](https://github.com/single-spa/single-spa-layout/assets/63799259/b40de73e-28c4-4b7b-87b8-356b962c5698)