### PR TITLE
Add missing className prop to Application type

### DIFF
--- a/src/isomorphic/constructRoutes.js
+++ b/src/isomorphic/constructRoutes.js
@@ -67,6 +67,7 @@ export const MISSING_PROP = typeof Symbol !== "undefined" ? Symbol() : "@";
  * name: string;
  * props?: object;
  * loader?: string | import('single-spa').ParcelConfig;
+ * className?: string;
  * }} Application
  *
  * @typedef {{


### PR DESCRIPTION
When using constructRoutes the application routes may accept a className property, which was missing from the type definition.