### PR TITLE
Modify routing event handling to do nothing if navigation is cancelled

### DIFF
--- a/src/browser/constructLayoutEngine.js
+++ b/src/browser/constructLayoutEngine.js
@@ -206,15 +206,18 @@ export function constructLayoutEngine({
     });
   }
 
-  function handleRoutingEvent({ detail: { newUrl } }) {
-    getAppsToUnmount(newUrl).forEach((name) => {
-      const applicationElement = document.getElementById(
-        applicationElementId(name)
-      );
-      if (applicationElement && applicationElement.isConnected) {
-        applicationElement.parentNode.removeChild(applicationElement);
-      }
-    });
+  function handleRoutingEvent({ detail: { navigationIsCanceled, newUrl } }) {
+    // only unmount if navigation is not cancelled
+    if (!navigationIsCanceled) {
+      getAppsToUnmount(newUrl).forEach((name) => {
+        const applicationElement = document.getElementById(
+          applicationElementId(name)
+        );
+        if (applicationElement && applicationElement.isConnected) {
+          applicationElement.parentNode.removeChild(applicationElement);
+        }
+      });
+    }
   }
 }
 


### PR DESCRIPTION
Fix the same problem found in #190 but with the previous major version. Currently, this fix is only present in the new 2.x version which depends on the latest beta for single-spa (currently 6.0.0-beta3). Updating to this version is technically not a problem but this can a problem for project which don't use betas.

I understand that the beta is deemed stable but the "beta" state in the version name and the fact that this beta is older then the newest 5.x version can scare a lot of people.