### PR TITLE
Export types from /server entrypoint

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     },
     "./server": {
       "node": {
-        "types": "./dist/types/single-spa-layout-server.d.ts",
+        "types": "./dist/types/single-spa-layout-server-interface.d.ts",
         "import": "./dist/esm/single-spa-layout-server.min.js",
         "require": "./dist/umd/single-spa-layout-server.min.cjs"
       }

--- a/src/server/index.ts
+++ b/src/server/index.ts
@@ -1,3 +1,3 @@
 // This file exists so that typescript understands the following:
 // import 'single-spa-layout/server'
-export * from "../single-spa-layout-server";
+export * from "../single-spa-layout-server-interface";

--- a/src/single-spa-layout-server-interface.ts
+++ b/src/single-spa-layout-server-interface.ts
@@ -1,0 +1,10 @@
+export * from "./single-spa-layout-server";
+export {
+  HTMLTemplateOptions,
+  ServerLayout,
+} from "./server/constructServerLayout";
+export {
+  AppToRender,
+  ApplicationRenderResult,
+  RenderResult,
+} from "./server/sendLayoutHTTPResponse";


### PR DESCRIPTION
Hello,

as suggested in #214, here's the MR to add type definitions for the package's `/server` entrypoint.
It follows the existing approach of the default entrypoint by adding `single-spa-layout-server-interface.ts` that reexports JS values and adds some type exports.